### PR TITLE
fix(cli): harden IDE integration file writes

### DIFF
--- a/apps/cli/src/__tests__/ide-integration.test.ts
+++ b/apps/cli/src/__tests__/ide-integration.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { setupIdes } from "../ide-integration.js";
+
+describe("IDE integration setup", () => {
+  const dirs: string[] = [];
+
+  function makeTempDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "unforgit-ide-test-"));
+    dirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const dir of dirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+  });
+
+  it("does not clobber markdown files created during setup", () => {
+    const dir = makeTempDir();
+    const claudePath = path.join(dir, "CLAUDE.md");
+    let injectedConcurrentCreate = false;
+    const realOpenSync = fs.openSync;
+    const realWriteFileSync = fs.writeFileSync;
+
+    vi.spyOn(fs, "openSync").mockImplementation((target, flags, mode) => {
+      if (target === claudePath && !injectedConcurrentCreate) {
+        injectedConcurrentCreate = true;
+        realWriteFileSync(claudePath, "# Existing project instructions\n", "utf-8");
+      }
+      return realOpenSync(target, flags, mode);
+    });
+
+    vi.spyOn(fs, "writeFileSync").mockImplementation((target, data, options) => {
+      if (target === claudePath && !injectedConcurrentCreate) {
+        injectedConcurrentCreate = true;
+        realWriteFileSync(claudePath, "# Existing project instructions\n", "utf-8");
+      }
+      return realWriteFileSync(target, data, options);
+    });
+
+    const [result] = setupIdes(dir, ["claude"]);
+
+    expect(result.rules?.action).toBe("updated");
+    const content = fs.readFileSync(claudePath, "utf-8");
+    expect(content).toContain("# Existing project instructions");
+    expect(content).toContain("Unforgit Memory Integration");
+  });
+
+  it("does not clobber MCP JSON files created during setup", () => {
+    const dir = makeTempDir();
+    const mcpPath = path.join(dir, ".mcp.json");
+    let injectedConcurrentCreate = false;
+    const realOpenSync = fs.openSync;
+    const realWriteFileSync = fs.writeFileSync;
+
+    function createExistingMcpFile(): void {
+      fs.mkdirSync(path.dirname(mcpPath), { recursive: true });
+      realWriteFileSync(
+        mcpPath,
+        JSON.stringify({ mcpServers: { existing: { command: "existing-mcp" } } }, null, 2) + "\n",
+        "utf-8",
+      );
+    }
+
+    vi.spyOn(fs, "openSync").mockImplementation((target, flags, mode) => {
+      if (target === mcpPath && !injectedConcurrentCreate) {
+        injectedConcurrentCreate = true;
+        createExistingMcpFile();
+      }
+      return realOpenSync(target, flags, mode);
+    });
+
+    vi.spyOn(fs, "writeFileSync").mockImplementation((target, data, options) => {
+      if (target === mcpPath && !injectedConcurrentCreate) {
+        injectedConcurrentCreate = true;
+        createExistingMcpFile();
+      }
+      return realWriteFileSync(target, data, options);
+    });
+
+    const [result] = setupIdes(dir, ["claude"]);
+
+    expect(result.mcp?.action).toBe("updated");
+    const config = JSON.parse(fs.readFileSync(mcpPath, "utf-8"));
+    expect(config.mcpServers.existing).toEqual({ command: "existing-mcp" });
+    expect(config.mcpServers.unforgit).toEqual({ command: "unforgit-mcp", args: [] });
+  });
+});

--- a/apps/cli/src/ide-integration.ts
+++ b/apps/cli/src/ide-integration.ts
@@ -62,11 +62,6 @@ interface IdeSetupResult {
   mcp?: SetupAction;
 }
 
-function fileContainsUnforgit(filePath: string): boolean {
-  if (!fs.existsSync(filePath)) return false;
-  return fs.readFileSync(filePath, "utf-8").includes(UNFORGIT_MARKER);
-}
-
 function upsertJsonMcp(
   filePath: string,
   serverKey: string,
@@ -75,26 +70,29 @@ function upsertJsonMcp(
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
 
-  if (!fs.existsSync(filePath)) {
-    const config = { [serverKey]: { unforgit: mcpEntry } };
-    fs.writeFileSync(filePath, JSON.stringify(config, null, 2) + "\n", "utf-8");
-    return { path: filePath, action: "created" };
-  }
+  const fd = fs.openSync(filePath, "a+");
+  try {
+    const raw = fs.readFileSync(fd, "utf-8");
+    if (raw.trim().length === 0) {
+      const config = { [serverKey]: { unforgit: mcpEntry } };
+      fs.writeSync(fd, JSON.stringify(config, null, 2) + "\n", 0, "utf-8");
+      return { path: filePath, action: "created" };
+    }
 
-  const existing = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-  const servers = existing[serverKey];
-  if (servers?.unforgit) {
-    return { path: filePath, action: "exists" };
-  }
+    const existing = JSON.parse(raw);
+    const servers = existing[serverKey];
+    if (servers?.unforgit) {
+      return { path: filePath, action: "exists" };
+    }
 
-  existing[serverKey] = existing[serverKey] || {};
-  existing[serverKey].unforgit = mcpEntry;
-  fs.writeFileSync(
-    filePath,
-    JSON.stringify(existing, null, 2) + "\n",
-    "utf-8",
-  );
-  return { path: filePath, action: "updated" };
+    existing[serverKey] = existing[serverKey] || {};
+    existing[serverKey].unforgit = mcpEntry;
+    fs.ftruncateSync(fd, 0);
+    fs.writeSync(fd, JSON.stringify(existing, null, 2) + "\n", 0, "utf-8");
+    return { path: filePath, action: "updated" };
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 function appendOrCreateMarkdown(
@@ -104,19 +102,46 @@ function appendOrCreateMarkdown(
   const dir = path.dirname(filePath);
   fs.mkdirSync(dir, { recursive: true });
 
-  if (!fs.existsSync(filePath)) {
-    fs.writeFileSync(filePath, content + "\n", "utf-8");
-    return { path: filePath, action: "created" };
-  }
+  const fd = fs.openSync(filePath, "a+");
+  try {
+    const existing = fs.readFileSync(fd, "utf-8");
+    if (existing.length === 0) {
+      fs.writeSync(fd, content + "\n", 0, "utf-8");
+      return { path: filePath, action: "created" };
+    }
 
-  if (fileContainsUnforgit(filePath)) {
-    return { path: filePath, action: "exists" };
-  }
+    if (existing.includes(UNFORGIT_MARKER)) {
+      return { path: filePath, action: "exists" };
+    }
 
-  const existing = fs.readFileSync(filePath, "utf-8");
-  const separator = existing.endsWith("\n") ? "\n" : "\n\n";
-  fs.writeFileSync(filePath, existing + separator + content + "\n", "utf-8");
-  return { path: filePath, action: "updated" };
+    const separator = existing.endsWith("\n") ? "\n" : "\n\n";
+    fs.writeSync(fd, separator + content + "\n", undefined, "utf-8");
+    return { path: filePath, action: "updated" };
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function replaceMarkdownIfMissingMarker(
+  filePath: string,
+  content: string,
+): SetupAction {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const fd = fs.openSync(filePath, "a+");
+  try {
+    const existing = fs.readFileSync(fd, "utf-8");
+    if (existing.includes(UNFORGIT_MARKER)) {
+      return { path: filePath, action: "exists" };
+    }
+
+    fs.ftruncateSync(fd, 0);
+    fs.writeSync(fd, content, 0, "utf-8");
+    return { path: filePath, action: existing.length === 0 ? "created" : "updated" };
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 // --- Cursor ---
@@ -132,15 +157,7 @@ ${MEMORY_INSTRUCTIONS}
 function setupCursor(cwd: string): IdeSetupResult {
   const rulesDir = path.join(cwd, ".cursor", "rules");
   const rulePath = path.join(rulesDir, "unforgit-memory.mdc");
-
-  let rules: SetupAction;
-  if (fileContainsUnforgit(rulePath)) {
-    rules = { path: rulePath, action: "exists" };
-  } else {
-    fs.mkdirSync(rulesDir, { recursive: true });
-    fs.writeFileSync(rulePath, CURSOR_RULE_CONTENT, "utf-8");
-    rules = { path: rulePath, action: "created" };
-  }
+  const rules = replaceMarkdownIfMissingMarker(rulePath, CURSOR_RULE_CONTENT);
 
   const mcpPath = path.join(cwd, ".cursor", "mcp.json");
   const mcp = upsertJsonMcp(mcpPath, "mcpServers", {


### PR DESCRIPTION
## Summary
- Replace check-then-write IDE setup paths with file-descriptor-based updates
- Preserve concurrently-created Markdown and MCP JSON files instead of clobbering them
- Add regression coverage for IDE setup file races

## Test plan
- pnpm vitest run apps/cli/src/__tests__/ide-integration.test.ts
- pnpm lint
- pnpm test
- DATABASE_URL='postgresql://unforgit:***@localhost:5432/unforgit' pnpm build

Closes #13