### PR TITLE
feat: improve memory maturity diagnostics

### DIFF
--- a/apps/cli/src/__tests__/commands/doctor.test.ts
+++ b/apps/cli/src/__tests__/commands/doctor.test.ts
@@ -61,7 +61,11 @@ describe("doctor command", () => {
         expect.objectContaining({ check: "memory-stats", status: "ok" }),
         expect.objectContaining({ check: "embeddings", status: "warn", fix: "Run 'unforgit embeddings backfill'." }),
         expect.objectContaining({ check: "tombstones", status: "ok" }),
-        expect.objectContaining({ check: "sync", status: "ok" }),
+        expect.objectContaining({
+          check: "sync",
+          status: "warn",
+          fix: "Run 'unforgit push' to publish local memory changes, or configure/disable sync if this repository is intentionally local-only.",
+        }),
         expect.objectContaining({ check: "remote", status: "warn", fix: "Run 'unforgit remote add origin <url>' if this repo should sync remotely." }),
       ]),
     );

--- a/apps/cli/src/__tests__/commands/embeddings.test.ts
+++ b/apps/cli/src/__tests__/commands/embeddings.test.ts
@@ -1,17 +1,20 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { createTempDataDir } from "../helpers.js";
+import { createTempDataDir, runCommand } from "../helpers.js";
 import { LocalStore } from "unforgit-db";
 
 describe("embeddings", () => {
   let tmpDir: ReturnType<typeof createTempDataDir>;
   let store: LocalStore;
+  let originalCwd: string;
 
   beforeEach(() => {
-    tmpDir = createTempDataDir();
+    originalCwd = process.cwd();
+    tmpDir = createTempDataDir({ remote: { url: "" } });
     store = new LocalStore(tmpDir.dbPath);
   });
 
   afterEach(() => {
+    process.chdir(originalCwd);
     store.close();
     tmpDir.cleanup();
   });
@@ -67,5 +70,30 @@ describe("embeddings", () => {
     const without = store.getMemoriesWithoutEmbeddings("test-org", "test-repo");
     expect(without.length).toBe(1);
     expect(without[0].text).toBe("no embedding");
+  });
+
+  it("backfill --dry-run --json reports planned work without requiring an OpenAI key", async () => {
+    process.chdir(tmpDir.dir);
+    store.store({
+      orgId: "test-org",
+      repoId: "test-repo",
+      memoryType: "semantic",
+      text: "needs embedding",
+      tags: [],
+      visibility: "auto",
+    });
+
+    const result = await runCommand(["embeddings", "backfill", "--dry-run", "--json"]);
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload).toMatchObject({
+      dryRun: true,
+      total: 1,
+      withEmbedding: 0,
+      withoutEmbedding: 1,
+      planned: 1,
+    });
+    expect(payload.memories[0]).toMatchObject({ textPreview: "needs embedding" });
   });
 });

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -13,6 +13,7 @@ interface DiagnosticResult {
   status: "ok" | "warn" | "error";
   message: string;
   fix?: string;
+  details?: Record<string, unknown>;
 }
 
 interface DoctorSummary {
@@ -111,6 +112,7 @@ export const doctorCommand = new Command("doctor")
 
         const pendingPush = store.getPendingPush();
         const conflicts = store.getConflicts();
+        const syncSummary = store.getSyncSummary(orgId, repoId);
         const unsyncedTombstones = store.getUnsyncedTombstones(orgId, repoId);
         if (unsyncedTombstones.length > 0) {
           results.push({
@@ -129,15 +131,21 @@ export const doctorCommand = new Command("doctor")
             status: "warn",
             message: `${conflicts.length} sync conflict(s) need resolution`,
             fix: "Resolve conflicts with 'unforgit pull --force' or 'unforgit push --force' after reviewing the desired source of truth.",
+            details: syncSummary,
           });
-        } else if (pendingPush.length > 0) {
+        } else if (pendingPush.length > 0 || syncSummary.pendingPull > 0) {
+          const parts: string[] = [];
+          if (pendingPush.length > 0) parts.push(`${pendingPush.length} memory(s) pending push`);
+          if (syncSummary.pendingPull > 0) parts.push(`${syncSummary.pendingPull} memory(s) pending pull`);
           results.push({
             check: "sync",
-            status: "ok",
-            message: `${pendingPush.length} memory(s) pending push`,
+            status: "warn",
+            message: parts.join(", "),
+            fix: "Run 'unforgit push' to publish local memory changes, or configure/disable sync if this repository is intentionally local-only.",
+            details: syncSummary,
           });
         } else {
-          results.push({ check: "sync", status: "ok", message: "Sync state clean" });
+          results.push({ check: "sync", status: "ok", message: "Sync state clean", details: syncSummary });
         }
       } finally {
         store.close();

--- a/apps/cli/src/commands/embeddings.ts
+++ b/apps/cli/src/commands/embeddings.ts
@@ -43,6 +43,21 @@ embeddingsCommand
       const memories = store.getMemoriesWithoutEmbeddings(orgId, repoId);
       const stats = store.getEmbeddingStats(orgId, repoId);
 
+      if (isJsonMode() && opts.dryRun) {
+        outputJson({
+          dryRun: true,
+          ...stats,
+          coverage: stats.total > 0 ? Number(((stats.withEmbedding / stats.total) * 100).toFixed(1)) : 0,
+          planned: memories.length,
+          memories: memories.slice(0, 10).map((memory) => ({
+            id: memory.id,
+            textPreview: memory.text.slice(0, 80),
+          })),
+          truncated: memories.length > 10,
+        });
+        return;
+      }
+
       logger.info(`Embedding stats:`);
       logger.info(`  Total memories: ${stats.total}`);
       logger.info(`  With embedding: ${stats.withEmbedding}`);
@@ -50,6 +65,10 @@ embeddingsCommand
       logger.info("");
 
       if (memories.length === 0) {
+        if (isJsonMode()) {
+          outputJson({ dryRun: Boolean(opts.dryRun), ...stats, planned: 0, processed: 0, errors: 0 });
+          return;
+        }
         logger.info("All memories already have embeddings.");
         return;
       }
@@ -103,6 +122,9 @@ embeddingsCommand
       logger.info(`\nBackfill complete:`);
       logger.info(`  Processed: ${processed}`);
       logger.info(`  Errors: ${errors}`);
+      if (isJsonMode()) {
+        outputJson({ dryRun: false, ...stats, planned: memories.length, processed, errors });
+      }
     } finally {
       store.close();
     }


### PR DESCRIPTION
## Summary
- Treat pending push/pull sync states as actionable doctor warnings with structured counts
- Add sync summary details to doctor JSON output
- Add JSON dry-run output for embeddings backfill so automation can inspect planned work without requiring an OpenAI key

## Test Plan
- pnpm vitest run apps/cli/src/__tests__/commands/embeddings.test.ts apps/cli/src/__tests__/commands/doctor.test.ts
- pnpm lint
- pnpm test
- DATABASE_URL='postgresql://unforgit:***@localhost:5432/unforgit' pnpm db:generate
- DATABASE_URL='postgresql://unforgit:***@localhost:5432/unforgit' pnpm build
- pnpm smoke:cli
- pnpm audit --audit-level moderate