### PR TITLE
feat(cli): back up before clearing embeddings

### DIFF
--- a/apps/cli/src/__tests__/commands/embeddings.test.ts
+++ b/apps/cli/src/__tests__/commands/embeddings.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
 import { createTempDataDir, runCommand } from "../helpers.js";
 import { LocalStore } from "unforgit-db";
 
@@ -95,5 +97,64 @@ describe("embeddings", () => {
       planned: 1,
     });
     expect(payload.memories[0]).toMatchObject({ textPreview: "needs embedding" });
+  });
+
+  it("embeddings clear creates a recoverable backup by default", async () => {
+    process.chdir(tmpDir.dir);
+    const memory = store.store({
+      orgId: "test-org",
+      repoId: "test-repo",
+      memoryType: "semantic",
+      text: "embedded memory",
+      tags: [],
+      visibility: "auto",
+    });
+    await store.storeEmbedding(memory.id, [0.1, 0.2, 0.3], "test-model");
+    store.close();
+
+    const result = await runCommand(["embeddings", "clear", "--yes"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Created local embeddings backup:");
+    const backupRoot = path.join(tmpDir.dataDir, "backups");
+    const backupNames = fs
+      .readdirSync(backupRoot)
+      .filter((name) => name.startsWith("embeddings-clear-"));
+    expect(backupNames).toHaveLength(1);
+
+    const backupStore = new LocalStore(path.join(backupRoot, backupNames[0], "local.db"));
+    try {
+      const embedding = backupStore.getEmbedding(memory.id);
+      expect(embedding).toBeDefined();
+      expect(embedding?.[0]).toBeCloseTo(0.1);
+    } finally {
+      backupStore.close();
+    }
+
+    store = new LocalStore(tmpDir.dbPath);
+    expect(store.getEmbedding(memory.id)).toBeUndefined();
+  });
+
+  it("embeddings clear --no-backup skips backup creation", async () => {
+    process.chdir(tmpDir.dir);
+    const memory = store.store({
+      orgId: "test-org",
+      repoId: "test-repo",
+      memoryType: "semantic",
+      text: "embedded memory without backup",
+      tags: [],
+      visibility: "auto",
+    });
+    await store.storeEmbedding(memory.id, [0.4, 0.5, 0.6], "test-model");
+    store.close();
+
+    const result = await runCommand(["embeddings", "clear", "--yes", "--no-backup"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain("Created local embeddings backup:");
+    expect(fs.existsSync(path.join(tmpDir.dataDir, "backups"))).toBe(false);
+
+    store = new LocalStore(tmpDir.dbPath);
+    expect(store.getEmbedding(memory.id)).toBeUndefined();
   });
 });

--- a/apps/cli/src/commands/backups.ts
+++ b/apps/cli/src/commands/backups.ts
@@ -59,8 +59,9 @@ function resolveBackupDir(backupRoot: string, backupName: string): string {
   return resolvedBackup;
 }
 
-export function createLocalResetBackup(
+export function createLocalDatabaseBackup(
   dbPath: string,
+  prefix: string,
   now: Date = new Date(),
 ): LocalResetBackup | null {
   if (!fs.existsSync(dbPath)) {
@@ -68,7 +69,7 @@ export function createLocalResetBackup(
   }
 
   const backupRoot = backupRootForDb(dbPath);
-  const baseName = `reset-${formatBackupTimestamp(now)}`;
+  const baseName = `${prefix}-${formatBackupTimestamp(now)}`;
   let backupDir = path.join(backupRoot, baseName);
   let suffix = 1;
   while (fs.existsSync(backupDir)) {
@@ -83,6 +84,13 @@ export function createLocalResetBackup(
   }
 
   return describeBackup(backupDir);
+}
+
+export function createLocalResetBackup(
+  dbPath: string,
+  now: Date = new Date(),
+): LocalResetBackup | null {
+  return createLocalDatabaseBackup(dbPath, "reset", now);
 }
 
 export function listLocalResetBackups(dbPath: string): LocalResetBackup[] {

--- a/apps/cli/src/commands/embeddings.ts
+++ b/apps/cli/src/commands/embeddings.ts
@@ -6,6 +6,7 @@ import { logger } from "../logger.js";
 import { EXIT_ERROR, EXIT_CONFIG_ERROR } from "../exit-codes.js";
 import { parsePositiveInt } from "unforgit-config";
 import { isJsonMode, outputJson } from "../utils.js";
+import { createLocalDatabaseBackup } from "./backups.js";
 
 const cwd = process.cwd();
 
@@ -175,6 +176,7 @@ embeddingsCommand
   .command("clear")
   .description("Remove all embeddings (requires regeneration)")
   .option("--yes", "Skip confirmation")
+  .option("--no-backup", "Skip automatic local database backup before clearing embeddings")
   .action(async (opts) => {
     if (!isInitialized(cwd)) {
       logger.error("Unforgit not initialized. Run 'unforgit init' first.");
@@ -188,6 +190,20 @@ embeddingsCommand
     }
 
     const dbPath = getDbPath(cwd);
+    if (opts.backup !== false) {
+      try {
+        const backup = createLocalDatabaseBackup(dbPath, "embeddings-clear");
+        if (backup) {
+          logger.info(`Created local embeddings backup: ${backup.dir}`);
+        }
+      } catch (err) {
+        logger.error(
+          `Failed to create local embeddings backup: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(EXIT_ERROR);
+      }
+    }
+
     const store = new LocalStore(dbPath);
 
     try {


### PR DESCRIPTION
## Summary
- Adds a reusable local database backup helper for destructive local operations.
- Makes `unforgit embeddings clear` create a recoverable local DB backup by default.
- Adds `--no-backup` as an explicit escape hatch for automation or intentional destructive cleanup.
- Covers default backup and skip-backup behavior with CLI tests.

## Context
This is the first approved v0.6.0 Memory Maturity increment focused on data-safety defaults.

## Test Plan
- `pnpm vitest run apps/cli/src/__tests__/commands/embeddings.test.ts apps/cli/src/__tests__/commands/backups.test.ts apps/cli/src/__tests__/commands/reset.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

Part of #36.
