### PR TITLE
feat(cli): report embedding backfill results

### DIFF
--- a/apps/cli/src/__tests__/commands/embeddings.test.ts
+++ b/apps/cli/src/__tests__/commands/embeddings.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { createTempDataDir, runCommand } from "../helpers.js";
+import { buildBackfillJsonPayload } from "../../commands/embeddings.js";
 import { LocalStore } from "unforgit-db";
 
 describe("embeddings", () => {
@@ -91,10 +92,22 @@ describe("embeddings", () => {
     const payload = JSON.parse(result.stdout);
     expect(payload).toMatchObject({
       dryRun: true,
-      total: 1,
-      withEmbedding: 0,
-      withoutEmbedding: 1,
+      model: "text-embedding-3-small",
       planned: 1,
+      processed: 0,
+      errors: 0,
+      statsBefore: {
+        total: 1,
+        withEmbedding: 0,
+        withoutEmbedding: 1,
+        coverage: 0,
+      },
+      statsAfter: {
+        total: 1,
+        withEmbedding: 0,
+        withoutEmbedding: 1,
+        coverage: 0,
+      },
     });
     expect(payload.memories[0]).toMatchObject({ textPreview: "needs embedding" });
   });
@@ -156,5 +169,28 @@ describe("embeddings", () => {
 
     store = new LocalStore(tmpDir.dbPath);
     expect(store.getEmbedding(memory.id)).toBeUndefined();
+  });
+
+  it("builds post-run backfill JSON with before/after coverage and failure details", () => {
+    const payload = buildBackfillJsonPayload({
+      dryRun: false,
+      model: "text-embedding-3-small",
+      statsBefore: { total: 4, withEmbedding: 1, withoutEmbedding: 3 },
+      statsAfter: { total: 4, withEmbedding: 3, withoutEmbedding: 1 },
+      planned: 3,
+      processed: 2,
+      failures: [{ id: "mem-3", textPreview: "failed memory", error: "rate limited" }],
+    });
+
+    expect(payload).toMatchObject({
+      dryRun: false,
+      model: "text-embedding-3-small",
+      planned: 3,
+      processed: 2,
+      errors: 1,
+      failures: [{ id: "mem-3", textPreview: "failed memory", error: "rate limited" }],
+      statsBefore: { total: 4, withEmbedding: 1, withoutEmbedding: 3, coverage: 25 },
+      statsAfter: { total: 4, withEmbedding: 3, withoutEmbedding: 1, coverage: 75 },
+    });
   });
 });

--- a/apps/cli/src/commands/embeddings.ts
+++ b/apps/cli/src/commands/embeddings.ts
@@ -10,6 +10,54 @@ import { createLocalDatabaseBackup } from "./backups.js";
 
 const cwd = process.cwd();
 
+type EmbeddingStats = {
+  total: number;
+  withEmbedding: number;
+  withoutEmbedding: number;
+};
+
+export type EmbeddingBackfillFailure = {
+  id: string;
+  textPreview: string;
+  error: string;
+};
+
+function embeddingCoverage(stats: EmbeddingStats): number {
+  return stats.total > 0 ? Number(((stats.withEmbedding / stats.total) * 100).toFixed(1)) : 0;
+}
+
+export function buildBackfillJsonPayload(options: {
+  dryRun: boolean;
+  model: string;
+  statsBefore: EmbeddingStats;
+  statsAfter?: EmbeddingStats;
+  planned: number;
+  processed: number;
+  failures?: EmbeddingBackfillFailure[];
+  previews?: Array<{ id: string; textPreview: string }>;
+  truncated?: boolean;
+}) {
+  const statsAfter = options.statsAfter ?? options.statsBefore;
+  const failures = options.failures ?? [];
+  return {
+    dryRun: options.dryRun,
+    model: options.model,
+    planned: options.planned,
+    processed: options.processed,
+    errors: failures.length,
+    failures,
+    statsBefore: {
+      ...options.statsBefore,
+      coverage: embeddingCoverage(options.statsBefore),
+    },
+    statsAfter: {
+      ...statsAfter,
+      coverage: embeddingCoverage(statsAfter),
+    },
+    ...(options.previews ? { memories: options.previews, truncated: Boolean(options.truncated) } : {}),
+  };
+}
+
 export const embeddingsCommand = new Command("embeddings")
   .description("Manage memory embeddings for semantic search");
 
@@ -45,17 +93,18 @@ embeddingsCommand
       const stats = store.getEmbeddingStats(orgId, repoId);
 
       if (isJsonMode() && opts.dryRun) {
-        outputJson({
+        outputJson(buildBackfillJsonPayload({
           dryRun: true,
-          ...stats,
-          coverage: stats.total > 0 ? Number(((stats.withEmbedding / stats.total) * 100).toFixed(1)) : 0,
+          model: opts.model,
+          statsBefore: stats,
           planned: memories.length,
-          memories: memories.slice(0, 10).map((memory) => ({
+          processed: 0,
+          previews: memories.slice(0, 10).map((memory) => ({
             id: memory.id,
             textPreview: memory.text.slice(0, 80),
           })),
           truncated: memories.length > 10,
-        });
+        }));
         return;
       }
 
@@ -67,7 +116,13 @@ embeddingsCommand
 
       if (memories.length === 0) {
         if (isJsonMode()) {
-          outputJson({ dryRun: Boolean(opts.dryRun), ...stats, planned: 0, processed: 0, errors: 0 });
+          outputJson(buildBackfillJsonPayload({
+            dryRun: Boolean(opts.dryRun),
+            model: opts.model,
+            statsBefore: stats,
+            planned: 0,
+            processed: 0,
+          }));
           return;
         }
         logger.info("All memories already have embeddings.");
@@ -91,7 +146,7 @@ embeddingsCommand
       const batchSize = parsePositiveInt(opts.batchSize, "batch-size");
       const delay = parsePositiveInt(opts.delay, "delay");
       let processed = 0;
-      let errors = 0;
+      const failures: EmbeddingBackfillFailure[] = [];
 
       logger.info(`\nGenerating embeddings (batch size: ${batchSize}, delay: ${delay}ms)...`);
 
@@ -109,8 +164,13 @@ embeddingsCommand
               processed++;
               logger.progress(processed, memories.length, "embeddings");
             } catch (err) {
-              errors++;
-              logger.error(`${memory.id.slice(0, 8)}: ${err instanceof Error ? err.message : err}`);
+              const message = err instanceof Error ? err.message : String(err);
+              failures.push({
+                id: memory.id,
+                textPreview: memory.text.slice(0, 80),
+                error: message,
+              });
+              logger.error(`${memory.id.slice(0, 8)}: ${message}`);
             }
           })
         );
@@ -122,9 +182,21 @@ embeddingsCommand
 
       logger.info(`\nBackfill complete:`);
       logger.info(`  Processed: ${processed}`);
-      logger.info(`  Errors: ${errors}`);
+      logger.info(`  Errors: ${failures.length}`);
+      const statsAfter = store.getEmbeddingStats(orgId, repoId);
       if (isJsonMode()) {
-        outputJson({ dryRun: false, ...stats, planned: memories.length, processed, errors });
+        outputJson(buildBackfillJsonPayload({
+          dryRun: false,
+          model: opts.model,
+          statsBefore: stats,
+          statsAfter,
+          planned: memories.length,
+          processed,
+          failures,
+        }));
+      }
+      if (failures.length > 0) {
+        process.exitCode = EXIT_ERROR;
       }
     } finally {
       store.close();


### PR DESCRIPTION
## Summary
- Adds structured before/after embedding coverage to `unforgit embeddings backfill --json`.
- Reports post-run stats, processed count, and detailed per-memory failures.
- Makes partial backfill failures visible to automation via a non-zero exit code while preserving successful embeddings.
- Updates dry-run JSON to match the same structured shape.

## Context
Second approved v0.6.0 Memory Maturity increment focused on robust embedding backfill reporting and partial-failure diagnostics.

## Test Plan
- `pnpm vitest run apps/cli/src/__tests__/commands/embeddings.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

Part of #36.
