### PR TITLE
feat(cli): clarify status sync JSON

### DIFF
--- a/apps/cli/src/__tests__/commands/status.test.ts
+++ b/apps/cli/src/__tests__/commands/status.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LocalStore } from "unforgit-db";
+import { createTempDataDir, runCommand } from "../helpers.js";
+
+describe("status command", () => {
+  let tmp: ReturnType<typeof createTempDataDir>;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmp = createTempDataDir();
+    process.chdir(tmp.dir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    tmp.cleanup();
+  });
+
+  it("explains pending sync actions in machine-readable status output", async () => {
+    const store = new LocalStore(tmp.dbPath);
+    try {
+      const local = store.store({
+        orgId: "test-org",
+        repoId: "test-repo",
+        memoryType: "semantic",
+        visibility: "repo",
+        text: "Local memory waiting to push",
+      });
+      store.initSyncStateForMemory(local.id);
+
+      const remote = store.store({
+        orgId: "test-org",
+        repoId: "test-repo",
+        memoryType: "semantic",
+        visibility: "repo",
+        text: "Remote memory waiting to pull",
+      });
+      store.setSyncState({
+        memoryId: remote.id,
+        localVersion: remote.version,
+        remoteVersion: remote.version + 1,
+        syncStatus: "pending_pull",
+        lastPulledAt: new Date("2026-01-02T03:04:05.000Z"),
+      });
+    } finally {
+      store.close();
+    }
+
+    const result = await runCommand(["status", "--json"]);
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload).toMatchObject({
+      remote: "http://localhost:3737",
+      remoteConfigured: true,
+      synced: 0,
+      pendingPush: 1,
+      pendingPull: 1,
+      conflicts: 0,
+      untracked: 0,
+      clean: false,
+    });
+    expect(payload.recommendations).toEqual([
+      "Run 'unforgit push' to publish local memory changes.",
+      "Run 'unforgit pull' to fetch remote memory changes.",
+    ]);
+    expect(payload.details.pendingPush[0]).toMatchObject({
+      id: expect.any(String),
+      preview: "Local memory waiting to push",
+      status: "active",
+      syncStatus: "pending_push",
+    });
+    expect(payload.details.pendingPull[0]).toMatchObject({
+      id: expect.any(String),
+      preview: "Remote memory waiting to pull",
+      syncStatus: "pending_pull",
+      remoteVersion: 2,
+      lastPulledAt: "2026-01-02T03:04:05.000Z",
+    });
+  });
+
+  it("marks local-only repositories as clean without sync recommendations when no changes are pending", async () => {
+    tmp.cleanup();
+    tmp = createTempDataDir({ remote: { url: "" } });
+    process.chdir(tmp.dir);
+
+    const result = await runCommand(["status", "--json"]);
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload).toMatchObject({
+      remote: null,
+      remoteConfigured: false,
+      clean: true,
+      pendingPush: 0,
+      pendingPull: 0,
+      conflicts: 0,
+      untracked: 0,
+      recommendations: [],
+    });
+  });
+});

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -5,6 +5,28 @@ import { EXIT_CONFIG_ERROR } from "../exit-codes.js";
 import { LocalStore } from "unforgit-db";
 import { truncate, isJsonMode, outputJson } from "../utils.js";
 
+type PendingSyncItem = {
+  memory: { id: string; text: string; status?: string };
+  syncState: {
+    localVersion?: number;
+    remoteVersion?: number;
+    lastPushedAt?: Date;
+    lastPulledAt?: Date;
+    syncStatus: string;
+  };
+};
+
+type StatusDetailsItem = {
+  id: string;
+  preview: string;
+  status?: string;
+  syncStatus: string;
+  localVersion?: number;
+  remoteVersion?: number;
+  lastPushedAt?: string;
+  lastPulledAt?: string;
+};
+
 export const statusCommand = new Command("status")
   .description("Show the working tree status (pending sync state)")
   .option("-s, --short", "Give the output in short format")
@@ -31,25 +53,42 @@ Examples:
       const remoteName = "origin";
 
       const pendingPush = store.getPendingPush();
+      const pendingPull = store.getSyncStatesByStatus("pending_pull")
+        .map((syncState) => {
+          const memory = store.getById(syncState.memoryId);
+          return memory ? { memory, syncState } : undefined;
+        })
+        .filter((item): item is PendingSyncItem => Boolean(item));
       const conflicts = store.getConflicts();
       const untracked = store.getUntrackedMemories(orgId, repoId);
       const summary = store.getSyncSummary(orgId, repoId);
 
       if (isJsonMode()) {
+        const clean = pendingPush.length === 0 && pendingPull.length === 0 && conflicts.length === 0 && untracked.length === 0;
         outputJson({
           remote: remoteUrl || null,
+          remoteConfigured: Boolean(remoteUrl),
+          synced: summary.synced,
           pendingPush: pendingPush.length,
+          pendingPull: pendingPull.length,
           conflicts: conflicts.length,
           untracked: untracked.length,
-          synced: summary.synced,
+          clean,
+          recommendations: buildRecommendations(Boolean(remoteUrl), pendingPush.length, pendingPull.length, conflicts.length, untracked.length),
+          details: {
+            pendingPush: pendingPush.map(toDetailsItem),
+            pendingPull: pendingPull.map(toDetailsItem),
+            conflicts: conflicts.map(toDetailsItem),
+            untracked: untracked.map((memory) => ({ id: memory.id, preview: truncate(memory.text, 80), status: memory.status })),
+          },
         });
         return;
       }
 
       if (opts.short) {
-        printShortStatus(pendingPush, conflicts, untracked);
+        printShortStatus(pendingPush, pendingPull, conflicts, untracked);
       } else {
-        printLongStatus(remoteName, remoteUrl, pendingPush, conflicts, untracked, summary);
+        printLongStatus(remoteName, remoteUrl, pendingPush, pendingPull, conflicts, untracked, summary);
       }
     } finally {
       store.close();
@@ -58,11 +97,15 @@ Examples:
 
 function printShortStatus(
   pendingPush: Array<{ memory: { id: string; text: string }; syncState: { syncStatus: string } }>,
+  pendingPull: PendingSyncItem[],
   conflicts: Array<{ memory: { id: string; text: string } }>,
   untracked: Array<{ id: string; text: string }>,
 ): void {
   for (const { memory } of pendingPush) {
     logger.info(`M  ${memory.id.slice(0, 8)} ${truncate(memory.text, 50)}`);
+  }
+  for (const { memory } of pendingPull) {
+    logger.info(`P  ${memory.id.slice(0, 8)} ${truncate(memory.text, 50)}`);
   }
   for (const { memory } of conflicts) {
     logger.info(`C  ${memory.id.slice(0, 8)} ${truncate(memory.text, 50)}`);
@@ -76,6 +119,7 @@ function printLongStatus(
   remoteName: string,
   remoteUrl: string,
   pendingPush: Array<{ memory: { id: string; text: string; status: string }; syncState: { syncStatus: string } }>,
+  pendingPull: PendingSyncItem[],
   conflicts: Array<{ memory: { id: string; text: string } }>,
   untracked: Array<{ id: string; text: string }>,
   summary: { synced: number; pendingPush: number; pendingPull: number; conflicts: number },
@@ -87,8 +131,8 @@ function printLongStatus(
   }
   logger.info("");
 
-  if (pendingPush.length === 0 && conflicts.length === 0 && untracked.length === 0) {
-    logger.info("Nothing to push, working tree clean");
+  if (pendingPush.length === 0 && pendingPull.length === 0 && conflicts.length === 0 && untracked.length === 0) {
+    logger.info("Nothing to push or pull, working tree clean");
     if (summary.synced > 0) {
       logger.info(`  ${summary.synced} memories synced with remote`);
     }
@@ -102,6 +146,16 @@ function printLongStatus(
     for (const { memory } of pendingPush) {
       const action = memory.status === "active" ? "new memory" : "modified";
       logger.info(`        ${action}:   ${memory.id.slice(0, 8)}... "${truncate(memory.text, 40)}"`);
+    }
+    logger.info("");
+  }
+
+  if (pendingPull.length > 0) {
+    logger.info("Changes to be pulled:");
+    logger.info('  (use "unforgit pull" to sync from remote)');
+    logger.info("");
+    for (const { memory } of pendingPull) {
+      logger.info(`        remote update: ${memory.id.slice(0, 8)}... "${truncate(memory.text, 40)}"`);
     }
     logger.info("");
   }
@@ -127,6 +181,47 @@ function printLongStatus(
     logger.info("");
   }
 
-  const total = pendingPush.length + conflicts.length + untracked.length;
+  const total = pendingPush.length + pendingPull.length + conflicts.length + untracked.length;
   logger.info(`${total} change(s) pending`);
+}
+
+function buildRecommendations(
+  remoteConfigured: boolean,
+  pendingPush: number,
+  pendingPull: number,
+  conflicts: number,
+  untracked: number,
+): string[] {
+  const recommendations: string[] = [];
+
+  if (!remoteConfigured && (pendingPush > 0 || pendingPull > 0 || untracked > 0)) {
+    recommendations.push("Configure a remote with 'unforgit remote add origin <url>' or keep this repository intentionally local-only.");
+    return recommendations;
+  }
+
+  if (conflicts > 0) {
+    recommendations.push("Review conflicts, then run 'unforgit pull --force' to accept remote or 'unforgit push --force' to keep local.");
+  }
+  if (pendingPush > 0 || untracked > 0) {
+    recommendations.push("Run 'unforgit push' to publish local memory changes.");
+  }
+  if (pendingPull > 0) {
+    recommendations.push("Run 'unforgit pull' to fetch remote memory changes.");
+  }
+
+  return recommendations;
+}
+
+function toDetailsItem(item: PendingSyncItem): StatusDetailsItem {
+  const { memory, syncState } = item;
+  return {
+    id: memory.id,
+    preview: truncate(memory.text, 80),
+    status: memory.status,
+    syncStatus: syncState.syncStatus,
+    localVersion: syncState.localVersion,
+    remoteVersion: syncState.remoteVersion,
+    lastPushedAt: syncState.lastPushedAt?.toISOString(),
+    lastPulledAt: syncState.lastPulledAt?.toISOString(),
+  };
 }

--- a/apps/website/app/docs/page.tsx
+++ b/apps/website/app/docs/page.tsx
@@ -450,6 +450,7 @@ $ unforgit history <memory-id>`}
             <Terminal
               title="Sync and remotes"
               code={`$ unforgit status -s
+$ unforgit status --json
 $ unforgit push origin --dry-run
 $ unforgit pull origin
 $ unforgit diff --stat
@@ -465,7 +466,10 @@ $ unforgit completion zsh >> ~/.zshrc
 $ unforgit auth status`}
             />
             <p className="text-sm text-dracula-foreground/70">
-              <code className="text-dracula-foreground/80">doctor</code> checks initialization,
+              <code className="text-dracula-foreground/80">status --json</code> exposes
+              stable automation fields for remote configuration, pending push/pull,
+              conflicts, clean state, recommendations, and per-memory previews.
+              <code className="text-dracula-foreground/80"> doctor</code> checks initialization,
               config shape and permissions, deprecated secret-bearing config keys,
               SQLite access, memory counts, embedding coverage, tombstones, sync state,
               remote health, and required environment variables. JSON output includes a


### PR DESCRIPTION
## Summary
- Expands `unforgit status --json` with explicit sync clarity fields: `remoteConfigured`, `pendingPull`, `clean`, `recommendations`, and per-memory `details`.
- Surfaces pending pull items in short/long human status output.
- Documents the automation-friendly status JSON in the website docs.

## Test Plan
- [x] `pnpm vitest run apps/cli/src/__tests__/commands/status.test.ts`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `DATABASE_URL='postgresql://unforgit:***@localhost:5432/unforgit' pnpm build`
- [x] `pnpm smoke:cli`

Part of #36.