### PR TITLE
feat(cli): back up before hard delete

### DIFF
--- a/apps/cli/src/__tests__/commands/delete.test.ts
+++ b/apps/cli/src/__tests__/commands/delete.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { createTempDataDir } from "../helpers.js";
+import fs from "node:fs";
+import path from "node:path";
+import { createTempDataDir, runCommand } from "../helpers.js";
 import { LocalStore } from "unforgit-db";
 
 describe("delete and restore", () => {
@@ -85,5 +87,56 @@ describe("delete and restore", () => {
 
     const ok = store.restore(m.id);
     expect(ok).toBe(false);
+  });
+
+  it("creates a recoverable backup before hard deleting a local memory", async () => {
+    const m = store.store({
+      orgId: "test-org",
+      repoId: "test-repo",
+      memoryType: "semantic",
+      text: "hard delete should still be recoverable from backup",
+      tags: [],
+      visibility: "auto",
+    });
+    store.close();
+
+    const result = await runCommand(["delete", m.id, "--hard", "--force"], { cwd: tmpDir.dir });
+
+    expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("Created local hard-delete backup:");
+
+    const backupRoot = path.join(tmpDir.dataDir, "backups");
+    const backups = fs.readdirSync(backupRoot).filter((entry) => entry.startsWith("hard-delete-"));
+    expect(backups).toHaveLength(1);
+
+    const backupStore = new LocalStore(path.join(backupRoot, backups[0], "local.db"));
+    try {
+      expect(backupStore.getById(m.id)?.text).toBe("hard delete should still be recoverable from backup");
+    } finally {
+      backupStore.close();
+    }
+
+    store = new LocalStore(tmpDir.dbPath);
+    expect(store.getById(m.id)).toBeFalsy();
+  });
+
+  it("allows explicitly skipping the hard-delete backup", async () => {
+    const m = store.store({
+      orgId: "test-org",
+      repoId: "test-repo",
+      memoryType: "semantic",
+      text: "hard delete without backup",
+      tags: [],
+      visibility: "auto",
+    });
+    store.close();
+
+    const result = await runCommand(["delete", m.id, "--hard", "--force", "--no-backup"], { cwd: tmpDir.dir });
+
+    expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir.dataDir, "backups"))).toBe(false);
+
+    store = new LocalStore(tmpDir.dbPath);
+    expect(store.getById(m.id)).toBeFalsy();
   });
 });

--- a/apps/cli/src/__tests__/helpers.ts
+++ b/apps/cli/src/__tests__/helpers.ts
@@ -88,6 +88,7 @@ export function restoreFetch(): void {
 
 export async function runCommand(
   args: string[],
+  options: { cwd?: string } = {},
 ): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
   const { execFile } = await import("node:child_process");
   const { promisify } = await import("node:util");
@@ -107,6 +108,7 @@ export async function runCommand(
     const { stdout, stderr } = await execFileAsync(tsxPath, [entryPoint, ...args], {
       timeout: 15_000,
       env: { ...process.env, NODE_ENV: "test", NODE_OPTIONS: nodeOptions },
+      cwd: options.cwd ?? process.cwd(),
     });
     return { stdout, stderr, exitCode: 0 };
   } catch (err: unknown) {

--- a/apps/cli/src/commands/delete.ts
+++ b/apps/cli/src/commands/delete.ts
@@ -5,6 +5,7 @@ import { RemoteClient } from "unforgit-config";
 import { logger } from "../logger.js";
 import { EXIT_ERROR } from "../exit-codes.js";
 import { confirm } from "../utils.js";
+import { createLocalDatabaseBackup } from "./backups.js";
 
 export const deleteCommand = new Command("delete")
   .description("Soft delete a memory (can be restored)")
@@ -13,10 +14,12 @@ export const deleteCommand = new Command("delete")
   .option("--remote", "Delete on remote")
   .option("--by <author>", "Author of the deletion")
   .option("--force", "Skip confirmation for hard delete")
+  .option("--no-backup", "Skip automatic local database backup before local hard delete")
   .addHelpText("after", `
 Examples:
   unforgit delete abc12345              Soft delete (can be restored)
-  unforgit delete abc12345 --hard       Permanent delete
+  unforgit delete abc12345 --hard       Permanent delete, with local backup by default
+  unforgit delete abc12345 --hard --no-backup
   unforgit delete abc12345 --remote     Delete on remote server`)
   .action(async (id, opts) => {
     if (opts.hard && !opts.force) {
@@ -46,7 +49,22 @@ Examples:
       return;
     }
 
-    const store = new LocalStore(getDbPath());
+    const dbPath = getDbPath();
+    if (opts.hard && opts.backup !== false) {
+      try {
+        const backup = createLocalDatabaseBackup(dbPath, "hard-delete");
+        if (backup) {
+          logger.info(`Created local hard-delete backup: ${backup.dir}`);
+        }
+      } catch (err) {
+        logger.error(
+          `Failed to create local hard-delete backup: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(EXIT_ERROR);
+      }
+    }
+
+    const store = new LocalStore(dbPath);
 
     try {
       let ok: boolean;

--- a/apps/website/app/docs/page.tsx
+++ b/apps/website/app/docs/page.tsx
@@ -420,6 +420,8 @@ $ unforgit unconsolidate <consolidation-id> --dry-run`}
 $ unforgit supersede <old-id> --with <new-id>
 $ unforgit delete <id>
 $ unforgit delete <id> --hard --force
+$ unforgit delete <id> --hard --force --no-backup
+$ unforgit backups list
 $ unforgit restore <id>`}
             />
           </div>


### PR DESCRIPTION
## Summary
- Creates a local database backup before `unforgit delete <id> --hard` by default.
- Adds an explicit `--no-backup` escape hatch for intentional permanent deletion without backup.
- Documents hard-delete backups in the website docs.
- Lets CLI command tests pass an explicit child-process cwd so destructive command tests operate on the intended temp repo.

## Test Plan
- [x] `pnpm vitest run apps/cli/src/__tests__/commands/delete.test.ts`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `DATABASE_URL='postgresql://unforgit:***@localhost:5432/unforgit' pnpm build`
- [x] `pnpm smoke:cli`

Part of #36.