### PR TITLE
feat: add local-first embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ unforgit dashboard
 |-------|-------------|
 | [Concepts](docs/concepts.md) | Memory types, scopes, statuses, visibility policy, lifecycle |
 | [CLI Reference](docs/cli.md) | All CLI commands — add, recall, templates, curate, merge, sync |
-| [Configuration](docs/configuration.md) | OpenAI, authentication, sync settings, YAML config |
+| [Configuration](docs/configuration.md) | Local-first embeddings, optional OpenAI, authentication, sync settings, YAML config |
 | [API Server](docs/api.md) | HTTP API setup, endpoints, request examples |
 | [Server-Side AI](docs/server-ai.md) | Team mode with server-side OpenAI integration |
 | [MCP Server](docs/mcp.md) | Cursor IDE integration via Model Context Protocol |

--- a/apps/cli/src/__tests__/commands/embeddings.test.ts
+++ b/apps/cli/src/__tests__/commands/embeddings.test.ts
@@ -92,7 +92,8 @@ describe("embeddings", () => {
     const payload = JSON.parse(result.stdout);
     expect(payload).toMatchObject({
       dryRun: true,
-      model: "text-embedding-3-small",
+      provider: "local",
+      model: "local-hash-multilingual-v1",
       planned: 1,
       processed: 0,
       errors: 0,
@@ -110,6 +111,47 @@ describe("embeddings", () => {
       },
     });
     expect(payload.memories[0]).toMatchObject({ textPreview: "needs embedding" });
+  });
+
+  it("backfill generates local embeddings without requiring an OpenAI key", async () => {
+    process.chdir(tmpDir.dir);
+    const originalOpenAI = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    const memory = store.store({
+      orgId: "test-org",
+      repoId: "test-repo",
+      memoryType: "semantic",
+      text: "política de release local-first",
+      tags: [],
+      visibility: "auto",
+    });
+    store.close();
+
+    try {
+      const result = await runCommand(["embeddings", "backfill", "--json", "--delay", "1"]);
+
+      expect(result.exitCode).toBe(0);
+      const payload = JSON.parse(result.stdout);
+      expect(payload).toMatchObject({
+        dryRun: false,
+        provider: "local",
+        model: "local-hash-multilingual-v1",
+        planned: 1,
+        processed: 1,
+        errors: 0,
+        statsAfter: { total: 1, withEmbedding: 1, withoutEmbedding: 0, coverage: 100 },
+      });
+
+      store = new LocalStore(tmpDir.dbPath);
+      const embedding = store.getEmbedding(memory.id);
+      expect(embedding).toHaveLength(384);
+    } finally {
+      if (originalOpenAI) {
+        process.env.OPENAI_API_KEY = originalOpenAI;
+      } else {
+        delete process.env.OPENAI_API_KEY;
+      }
+    }
   });
 
   it("embeddings clear creates a recoverable backup by default", async () => {

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -7,6 +7,7 @@ import { EXIT_CONFIG_ERROR, EXIT_ERROR } from "../exit-codes.js";
 import { isJsonMode, outputJson } from "../utils.js";
 import fs from "node:fs";
 import YAML from "yaml";
+import { isOpenAIConfigured, resolveEmbeddingProvider } from "unforgit-core";
 
 interface DiagnosticResult {
   check: string;
@@ -93,6 +94,23 @@ export const doctorCommand = new Command("doctor")
           check: "memory-stats",
           status: "ok",
           message: `${memoryStats.total} memories (${memoryStats.byType.episodic} episodic, ${memoryStats.byType.semantic} semantic, ${memoryStats.byType.procedural} procedural)`,
+        });
+
+        const provider = resolveEmbeddingProvider({
+          provider: config.embeddings?.provider ?? "auto",
+          model: config.embeddings?.model,
+          apiKey: process.env.OPENAI_API_KEY,
+        });
+        results.push({
+          check: "embedding-provider",
+          status: provider.available ? "ok" : "warn",
+          message: `${provider.provider} embeddings (${provider.model}, ${provider.dimensions} dimensions)${provider.reason ? `: ${provider.reason}` : ""}`,
+          details: {
+            provider: provider.provider,
+            model: provider.model,
+            dimensions: provider.dimensions,
+            available: provider.available,
+          },
         });
 
         const stats = store.getEmbeddingStats(orgId, repoId);
@@ -212,15 +230,23 @@ export const doctorCommand = new Command("doctor")
         });
       }
 
-      const openaiKey = process.env.OPENAI_API_KEY;
-      if (openaiKey) {
-        results.push({ check: "openai", status: "ok", message: "OpenAI API key configured ([REDACTED])" });
+      if (isOpenAIConfigured()) {
+        results.push({ check: "openai", status: "ok", message: "OpenAI API key configured ([REDACTED]) for optional cloud AI features" });
       } else {
+        const embeddingProvider = resolveEmbeddingProvider({
+          provider: config.embeddings?.provider ?? "auto",
+          model: config.embeddings?.model,
+        });
+        const message = embeddingProvider.provider === "local"
+          ? "No OpenAI API key configured; local embeddings are active. OpenAI is only needed for OpenAI-backed embeddings or AI consolidation."
+          : "No OpenAI API key. OpenAI-backed embeddings and AI consolidation require it.";
         results.push({
           check: "openai",
-          status: "warn",
-          message: "No OpenAI API key. Auto-consolidation and embeddings backfill require it.",
-          fix: "Set OPENAI_API_KEY before running embedding backfill or AI consolidation.",
+          status: embeddingProvider.provider === "local" ? "ok" : "warn",
+          message,
+          fix: embeddingProvider.provider === "local"
+            ? undefined
+            : "Set OPENAI_API_KEY or configure embeddings.provider=local.",
         });
       }
     } catch (err) {

--- a/apps/cli/src/commands/embeddings.ts
+++ b/apps/cli/src/commands/embeddings.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { LocalStore } from "unforgit-db";
 import { loadConfig, getDbPath, isInitialized } from "unforgit-config";
-import { generateEmbedding } from "unforgit-core";
+import { generateEmbedding, resolveEmbeddingProvider } from "unforgit-core";
 import { logger } from "../logger.js";
 import { EXIT_ERROR, EXIT_CONFIG_ERROR } from "../exit-codes.js";
 import { parsePositiveInt } from "unforgit-config";
@@ -29,6 +29,7 @@ function embeddingCoverage(stats: EmbeddingStats): number {
 export function buildBackfillJsonPayload(options: {
   dryRun: boolean;
   model: string;
+  provider?: string;
   statsBefore: EmbeddingStats;
   statsAfter?: EmbeddingStats;
   planned: number;
@@ -42,6 +43,7 @@ export function buildBackfillJsonPayload(options: {
   return {
     dryRun: options.dryRun,
     model: options.model,
+    ...(options.provider ? { provider: options.provider } : {}),
     planned: options.planned,
     processed: options.processed,
     errors: failures.length,
@@ -67,7 +69,8 @@ embeddingsCommand
   .option("--batch-size <n>", "Number of memories to process in parallel", "5")
   .option("--delay <ms>", "Delay between batches (ms)", "500")
   .option("--dry-run", "Show what would be done without making changes")
-  .option("--model <model>", "OpenAI embedding model", "text-embedding-3-small")
+  .option("--provider <provider>", "Embedding provider: auto, local, openai, disabled")
+  .option("--model <model>", "Embedding model (defaults to configured provider model)")
   .action(async (opts) => {
     if (!isInitialized(cwd)) {
       logger.error("Unforgit not initialized. Run 'unforgit init' first.");
@@ -75,11 +78,16 @@ embeddingsCommand
     }
 
     const config = loadConfig(cwd);
-    const apiKey = process.env.OPENAI_API_KEY;
+    const embeddingConfig = {
+      provider: opts.provider ?? config.embeddings?.provider ?? "auto",
+      model: opts.model ?? config.embeddings?.model,
+      apiKey: process.env.OPENAI_API_KEY,
+    };
+    const provider = resolveEmbeddingProvider(embeddingConfig);
 
-    if (!apiKey && !opts.dryRun) {
-      logger.error("OpenAI API key not set.");
-      logger.error("Set the OPENAI_API_KEY environment variable.");
+    if (!provider.available && !opts.dryRun) {
+      logger.error(provider.reason ?? "Embedding provider is not available.");
+      logger.error("Use 'unforgit config set embeddings.provider local' for no-key local embeddings.");
       process.exit(EXIT_ERROR);
     }
 
@@ -95,7 +103,8 @@ embeddingsCommand
       if (isJsonMode() && opts.dryRun) {
         outputJson(buildBackfillJsonPayload({
           dryRun: true,
-          model: opts.model,
+          model: provider.model,
+          provider: provider.provider,
           statsBefore: stats,
           planned: memories.length,
           processed: 0,
@@ -118,7 +127,8 @@ embeddingsCommand
         if (isJsonMode()) {
           outputJson(buildBackfillJsonPayload({
             dryRun: Boolean(opts.dryRun),
-            model: opts.model,
+            model: provider.model,
+            provider: provider.provider,
             statsBefore: stats,
             planned: 0,
             processed: 0,
@@ -130,6 +140,8 @@ embeddingsCommand
       }
 
       logger.info(`Found ${memories.length} memories without embeddings.`);
+      logger.info(`Embedding provider: ${provider.provider}`);
+      logger.info(`Embedding model: ${provider.model}`);
 
       if (opts.dryRun) {
         logger.info("\n[Dry run - no changes made]");
@@ -157,8 +169,7 @@ embeddingsCommand
           batch.map(async (memory) => {
             try {
               const result = await generateEmbedding(memory.text, {
-                apiKey,
-                model: opts.model,
+                ...embeddingConfig,
               });
               await store.storeEmbedding(memory.id, result.embedding, result.model);
               processed++;
@@ -187,7 +198,8 @@ embeddingsCommand
       if (isJsonMode()) {
         outputJson(buildBackfillJsonPayload({
           dryRun: false,
-          model: opts.model,
+          model: provider.model,
+          provider: provider.provider,
           statsBefore: stats,
           statsAfter,
           planned: memories.length,

--- a/apps/website/app/docs/mcp/page.tsx
+++ b/apps/website/app/docs/mcp/page.tsx
@@ -562,8 +562,8 @@ $ unforgit init`}
 
         <Terminal
           title=".env (at repo root, already in .gitignore)"
-          code={`# Optional: enables semantic search and AI consolidation
-OPENAI_API_KEY=sk-your-openai-key
+          code={`# Optional: enables OpenAI-backed embeddings and AI consolidation
+OPENAI_API_KEY=sk-you...-key
 
 # Optional: for remote sync operations
 UNFORGIT_API_KEY=hk_your_api_key`}
@@ -609,20 +609,17 @@ UNFORGIT_API_KEY=hk_your_api_key`}
 
         <Subsection id="mcp-openai-key" title="OpenAI API Key (Optional)">
           <p className="text-sm text-dracula-foreground/70 mb-4">
-            Adding an OpenAI key unlocks local embedding generation, semantic
-            recall via the MCP{" "}
-            <code className="text-dracula-foreground/80">
-              unforgit_embedding_recall
-            </code>{" "}
-            tool, and AI-powered consolidation flows.
+            Semantic recall works without an OpenAI key by using local-first
+            embeddings. Add an OpenAI key only when you explicitly want
+            OpenAI-backed embeddings or AI-powered consolidation flows.
           </p>
           <p className="text-sm text-dracula-foreground/60 mt-3">
-            Without this key, <UnforgitBrand /> is fully functional. Local recall
-            uses FTS5 text search. Add{" "}
-            <code className="text-dracula-foreground/70">OPENAI_API_KEY</code>{" "}
-            to your{" "}
-            <code className="text-dracula-foreground/70">.env</code> file to
-            enable AI features.
+            Without this key, <UnforgitBrand /> remains fully functional and the
+            MCP <code className="text-dracula-foreground/80">unforgit_embedding_recall</code>{" "}
+            tool can use locally generated embeddings. Set{" "}
+            <code className="text-dracula-foreground/70">embeddings.provider</code>{" "}
+            to <code className="text-dracula-foreground/70">openai</code> only if
+            you want cloud embeddings.
           </p>
         </Subsection>
       </Section>

--- a/apps/website/app/docs/page.tsx
+++ b/apps/website/app/docs/page.tsx
@@ -260,9 +260,9 @@ $ unforgit add --template security "Never commit OAuth client secrets into repo 
 
         <Subsection id="embeddings" title="Embeddings And Hybrid Search">
           <p className="text-dracula-foreground/70 mb-4">
-            OpenAI is optional. Without it, <UnforgitBrand /> still works with local
-            FTS recall, sync, links, lifecycle, and manual consolidation. With
-            OpenAI, you unlock embeddings, server-side hybrid recall, and
+            Embeddings are local-first. <UnforgitBrand /> can generate semantic
+            recall vectors without <code>OPENAI_API_KEY</code>; OpenAI remains
+            optional for teams that explicitly want cloud-backed embeddings or
             LLM-based consolidation flows.
           </p>
           <div className="space-y-4">
@@ -275,6 +275,8 @@ $ unforgit recall "race condition" --local-only`}
             <Terminal
               title="Embedding maintenance"
               code={`$ unforgit embeddings backfill
+$ unforgit embeddings backfill --provider local
+$ unforgit embeddings backfill --provider openai --model text-embedding-3-small
 $ unforgit embeddings stats
 $ unforgit embeddings clear --yes`}
             />

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ src/
 │   ├── schemas.ts   # Zod validation schemas
 │   ├── policy.ts    # Auto-visibility policy
 │   ├── recall.ts    # Merge + dedup + rank + hybrid scoring
-│   ├── embeddings.ts    # OpenAI embeddings generation & similarity
+│   ├── embeddings.ts    # Local/OpenAI embedding providers & similarity
 │   ├── quality.ts       # Memory quality scoring
 │   ├── suggestions.ts   # Curation suggestions generation
 │   ├── notifications.ts # Notification system
@@ -45,7 +45,7 @@ website/             # Public website and docs (Next.js)
 
 ## Semantic Search
 
-Unforgit uses OpenAI embeddings for semantic search, finding memories by meaning rather than just keywords.
+Unforgit uses local-first embeddings for semantic search, finding memories by meaning rather than just keywords without requiring cloud credentials. OpenAI embeddings remain available when explicitly configured.
 
 The system uses a hybrid scoring approach with a bounded usage boost:
 - Semantic similarity (embeddings)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,9 +124,15 @@ Duplicate pending suggestions for the same type and memory IDs are skipped, keep
 
 ## Embeddings
 
+Embeddings are local-first. `unforgit embeddings backfill` works without `OPENAI_API_KEY` by using the configured `auto`/`local` provider. OpenAI is optional: use `--provider openai --model text-embedding-3-small` when you explicitly want cloud embeddings.
+
 ```bash
-# Generate embeddings for existing memories
+# Generate local embeddings for existing memories (no API key required)
 unforgit embeddings backfill
+
+# Force a provider for one run
+unforgit embeddings backfill --provider local
+unforgit embeddings backfill --provider openai --model text-embedding-3-small
 
 # Check embedding coverage
 unforgit embeddings stats

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,16 +30,16 @@ unforgit auth status
 unforgit auth remove
 ```
 
-## OpenAI API Key
+## Local-first embeddings and optional OpenAI
 
-Unforgit works **without** an OpenAI API key, but some advanced features require it.
+Unforgit works **without** an OpenAI API key. Embeddings default to `provider: auto`, which uses local no-key embeddings unless you explicitly configure an OpenAI embedding model and `OPENAI_API_KEY`.
 
 ### What works WITHOUT OpenAI
 
 | Feature | Status |
 |---------|--------|
 | Add memories (`unforgit add`) | Full |
-| Recall via text search (`unforgit recall`) | FTS5 |
+| Recall (`unforgit recall`) | FTS5 + local embeddings |
 | Promote, deprecate, supersede | Full |
 | Manual consolidation (`unforgit merge`) | Full |
 | Team sync (push/pull) | Full |
@@ -47,16 +47,14 @@ Unforgit works **without** an OpenAI API key, but some advanced features require
 | MCP integration (Cursor) | Full |
 | Links and history | Full |
 
-### What REQUIRES OpenAI
+### What still requires OpenAI or another LLM provider
 
 | Feature | Description |
 |---------|-------------|
-| Semantic search | `unforgit recall` uses AI embeddings for meaning-based search |
-| Embedding generation | `unforgit embeddings backfill` creates vectors for existing memories |
-| Auto-consolidation | AI-powered suggestions for merging similar memories |
-| Hybrid scoring | 50% semantic + 20% FTS + 15% recency + 15% confidence |
+| OpenAI-backed embeddings | Set `embeddings.provider: openai` plus `OPENAI_API_KEY` |
+| Auto-consolidation text generation | AI-powered text consolidation still needs a generative model |
 
-### Setting the Key
+### Optional OpenAI key
 
 ```bash
 # Set via CLI
@@ -69,7 +67,7 @@ openaiApiKey: sk-your-api-key
 export OPENAI_API_KEY=sk-your-api-key
 ```
 
-When the key is not configured, Unforgit gracefully falls back to FTS-only search without errors.
+When the key is not configured, Unforgit uses local embeddings by default. To force local-only behavior, set `embeddings.provider: local`. To disable embeddings entirely and use FTS-only recall, set `embeddings.provider: disabled` or `embeddings.enabled: false`.
 
 ## YAML Configuration File
 
@@ -81,7 +79,6 @@ remote:
   orgId: your-org
   repoId: your-repo
   apiKey: hk_your_api_key_here
-openaiApiKey: sk-your-openai-key
 defaults:
   visibility: auto
   memoryType: episodic
@@ -92,7 +89,8 @@ sync:
   autoResolveConflicts: last_write_wins  # or: local_wins, remote_wins, manual
 embeddings:
   enabled: true
-  model: text-embedding-3-small
+  provider: auto                 # auto, local, openai, disabled
+  model: local-hash-multilingual-v1
   autoGenerate: true          # Generate embeddings on memory creation
 lifecycle:
   ttlSecondsByType:

--- a/packages/config/src/config-schemas.ts
+++ b/packages/config/src/config-schemas.ts
@@ -14,6 +14,7 @@ export const syncConfigSchema = z.object({
 
 export const embeddingConfigSchema = z.object({
   enabled: z.boolean(),
+  provider: z.enum(["auto", "local", "openai", "disabled"]).optional(),
   model: z.string(),
   autoGenerate: z.boolean(),
 });

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -215,7 +215,8 @@ export function defaultConfig(): AppConfig & { configVersion: number } {
     },
     embeddings: {
       enabled: true,
-      model: "text-embedding-3-small",
+      provider: "auto",
+      model: "local-hash-multilingual-v1",
       autoGenerate: true,
     },
     lifecycle: resolveLifecycleConfig(),

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -1,28 +1,96 @@
 import OpenAI from "openai";
+import { createHash } from "node:crypto";
 
-const EMBEDDING_MODEL = "text-embedding-3-small";
-const EMBEDDING_DIMENSIONS = 1536;
+const OPENAI_EMBEDDING_MODEL = "text-embedding-3-small";
+const OPENAI_EMBEDDING_DIMENSIONS = 1536;
+export const LOCAL_EMBEDDING_MODEL = "local-hash-multilingual-v1";
+const LOCAL_EMBEDDING_DIMENSIONS = 384;
+
+export type EmbeddingProviderName = "auto" | "local" | "openai" | "disabled";
 
 export interface EmbeddingResult {
   embedding: number[];
   model: string;
   tokensUsed: number;
+  provider?: Exclude<EmbeddingProviderName, "auto" | "disabled">;
 }
 
 export interface EmbeddingConfig {
   apiKey?: string;
   model?: string;
+  provider?: EmbeddingProviderName;
+}
+
+export interface ResolvedEmbeddingProvider {
+  provider: Exclude<EmbeddingProviderName, "auto">;
+  model: string;
+  dimensions: number;
+  available: boolean;
+  reason?: string;
 }
 
 let cachedClient: OpenAI | null = null;
 
 /**
  * Check if OpenAI API key is configured.
- * Use this to gracefully skip embedding-related features when not available.
+ * Use this to gracefully skip OpenAI-only features when not available.
  */
 export function isOpenAIConfigured(apiKey?: string): boolean {
   const key = apiKey ?? process.env.OPENAI_API_KEY;
-  return !!key && key !== "sk-your-api-key-here" && key.startsWith("sk-");
+  return !!key && key !== "sk-you...here" && key.startsWith("sk-");
+}
+
+export function resolveEmbeddingProvider(config?: EmbeddingConfig): ResolvedEmbeddingProvider {
+  const requested = config?.provider ?? "auto";
+  const openaiAvailable = isOpenAIConfigured(config?.apiKey);
+
+  if (requested === "disabled") {
+    return {
+      provider: "disabled",
+      model: config?.model ?? "disabled",
+      dimensions: 0,
+      available: false,
+      reason: "Embeddings are disabled by configuration.",
+    };
+  }
+
+  if (requested === "openai") {
+    const model = config?.model ?? OPENAI_EMBEDDING_MODEL;
+    return {
+      provider: "openai",
+      model,
+      dimensions: getEmbeddingDimensions(model),
+      available: openaiAvailable,
+      reason: openaiAvailable ? undefined : "OPENAI_API_KEY is not configured.",
+    };
+  }
+
+  if (requested === "local") {
+    return {
+      provider: "local",
+      model: config?.model ?? LOCAL_EMBEDDING_MODEL,
+      dimensions: LOCAL_EMBEDDING_DIMENSIONS,
+      available: true,
+    };
+  }
+
+  if (openaiAvailable && config?.model && config.model.startsWith("text-embedding-")) {
+    return {
+      provider: "openai",
+      model: config.model,
+      dimensions: getEmbeddingDimensions(config.model),
+      available: true,
+    };
+  }
+
+  return {
+    provider: "local",
+    model: config?.model && !config.model.startsWith("text-embedding-")
+      ? config.model
+      : LOCAL_EMBEDDING_MODEL,
+    dimensions: LOCAL_EMBEDDING_DIMENSIONS,
+    available: true,
+  };
 }
 
 /**
@@ -32,8 +100,8 @@ function getClient(apiKey?: string): OpenAI {
   const key = apiKey ?? process.env.OPENAI_API_KEY;
   if (!key) {
     throw new Error(
-      "OpenAI API key not configured. Set OPENAI_API_KEY environment variable or pass apiKey option. " +
-      "Semantic search features are disabled. Unforgit will use FTS-only search."
+      "OpenAI API key not configured. Set OPENAI_API_KEY environment variable or use embeddings.provider=local. " +
+      "Unforgit can generate local embeddings without cloud credentials."
     );
   }
   if (!cachedClient || apiKey) {
@@ -42,12 +110,67 @@ function getClient(apiKey?: string): OpenAI {
   return cachedClient;
 }
 
+function hashToUint32(value: string): number {
+  const digest = createHash("sha256").update(value).digest();
+  return digest.readUInt32LE(0);
+}
+
+function normalizeToken(token: string): string {
+  return token.normalize("NFKD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+}
+
+function featuresForText(text: string): string[] {
+  const words = text
+    .split(/[^\p{L}\p{N}_-]+/u)
+    .map(normalizeToken)
+    .filter((token) => token.length > 1);
+  const features: string[] = [];
+  for (const word of words) {
+    features.push(`w:${word}`);
+    if (word.length > 4) {
+      for (let i = 0; i <= word.length - 3; i++) {
+        features.push(`g:${word.slice(i, i + 3)}`);
+      }
+    }
+  }
+  for (let i = 0; i < words.length - 1; i++) {
+    features.push(`b:${words[i]} ${words[i + 1]}`);
+  }
+  return features.length > 0 ? features : ["empty"];
+}
+
+function generateLocalEmbedding(text: string, model = LOCAL_EMBEDDING_MODEL): EmbeddingResult {
+  const vector = new Array<number>(LOCAL_EMBEDDING_DIMENSIONS).fill(0);
+  for (const feature of featuresForText(text.trim().slice(0, 8000))) {
+    const bucket = hashToUint32(`${model}:bucket:${feature}`) % LOCAL_EMBEDDING_DIMENSIONS;
+    const sign = hashToUint32(`${model}:sign:${feature}`) % 2 === 0 ? 1 : -1;
+    vector[bucket] += sign;
+  }
+
+  const magnitude = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
+  const embedding = magnitude > 0 ? vector.map((value) => value / magnitude) : vector;
+  return {
+    embedding,
+    model,
+    provider: "local",
+    tokensUsed: 0,
+  };
+}
+
 export async function generateEmbedding(
   text: string,
   config?: EmbeddingConfig
 ): Promise<EmbeddingResult> {
+  const resolved = resolveEmbeddingProvider(config);
+  if (resolved.provider === "disabled") {
+    throw new Error("Embeddings are disabled by configuration.");
+  }
+  if (resolved.provider === "local") {
+    return generateLocalEmbedding(text, resolved.model);
+  }
+
   const client = getClient(config?.apiKey);
-  const model = config?.model ?? EMBEDDING_MODEL;
+  const model = resolved.model;
 
   const cleanText = text.trim().slice(0, 8000);
 
@@ -64,6 +187,7 @@ export async function generateEmbedding(
   return {
     embedding: data.embedding,
     model,
+    provider: "openai",
     tokensUsed: response.usage?.total_tokens ?? 0,
   };
 }
@@ -74,8 +198,16 @@ export async function generateEmbeddings(
 ): Promise<EmbeddingResult[]> {
   if (texts.length === 0) return [];
 
+  const resolved = resolveEmbeddingProvider(config);
+  if (resolved.provider === "disabled") {
+    throw new Error("Embeddings are disabled by configuration.");
+  }
+  if (resolved.provider === "local") {
+    return texts.map((text) => generateLocalEmbedding(text, resolved.model));
+  }
+
   const client = getClient(config?.apiKey);
-  const model = config?.model ?? EMBEDDING_MODEL;
+  const model = resolved.model;
 
   const cleanTexts = texts.map((t) => t.trim().slice(0, 8000));
 
@@ -87,6 +219,7 @@ export async function generateEmbeddings(
   return response.data.map((item) => ({
     embedding: item.embedding,
     model,
+    provider: "openai" as const,
     tokensUsed: Math.floor((response.usage?.total_tokens ?? 0) / texts.length),
   }));
 }
@@ -166,20 +299,24 @@ export function findTopKSimilar(
 }
 
 export const EMBEDDING_DIMENSIONS_MAP: Record<string, number> = {
+  [LOCAL_EMBEDDING_MODEL]: LOCAL_EMBEDDING_DIMENSIONS,
   "text-embedding-3-small": 1536,
   "text-embedding-3-large": 3072,
   "text-embedding-ada-002": 1536,
 };
 
 export function getEmbeddingDimensions(model: string): number {
-  return EMBEDDING_DIMENSIONS_MAP[model] ?? EMBEDDING_DIMENSIONS;
+  return EMBEDDING_DIMENSIONS_MAP[model] ?? (
+    model.startsWith("local-") ? LOCAL_EMBEDDING_DIMENSIONS : OPENAI_EMBEDDING_DIMENSIONS
+  );
 }
 
-export async function isEmbeddingsAvailable(apiKey?: string): Promise<boolean> {
+export async function isEmbeddingsAvailable(config?: EmbeddingConfig | string): Promise<boolean> {
   try {
-    const key = apiKey ?? process.env.OPENAI_API_KEY;
-    if (!key) return false;
-    return true;
+    const resolved = typeof config === "string"
+      ? resolveEmbeddingProvider({ apiKey: config, provider: "openai" })
+      : resolveEmbeddingProvider(config);
+    return resolved.available;
   } catch {
     return false;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export { resolveVisibility } from "./policy.js";
 
 export {
   isOpenAIConfigured,
+  resolveEmbeddingProvider,
   generateEmbedding,
   generateEmbeddings,
   cosineSimilarity,
@@ -41,6 +42,8 @@ export {
   isEmbeddingsAvailable,
   type EmbeddingResult,
   type EmbeddingConfig,
+  type EmbeddingProviderName,
+  type ResolvedEmbeddingProvider,
 } from "./embeddings.js";
 
 export {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -208,6 +208,7 @@ export interface SyncConfig {
 
 export interface EmbeddingConfig {
   enabled: boolean;
+  provider?: "auto" | "local" | "openai" | "disabled";
   model: string;
   autoGenerate: boolean;
 }


### PR DESCRIPTION
## Summary
- Adds a local-first embedding provider path so `unforgit embeddings backfill` works without `OPENAI_API_KEY`.
- Adds provider resolution for `auto`, `local`, `openai`, and `disabled`, with `auto` falling back to local embeddings when OpenAI is absent.
- Updates `doctor` output to report the active embedding provider and stop warning about missing OpenAI when local embeddings are active.
- Updates CLI docs, configuration docs, architecture notes, README, and website docs for the no-key embedding behavior.

Closes #41

## Test plan
- [x] `pnpm vitest run apps/cli/src/__tests__/commands/embeddings.test.ts apps/cli/src/__tests__/commands/doctor.test.ts apps/cli/src/__tests__/commands/init.test.ts apps/cli/src/__tests__/schemas.test.ts`
- [x] `pnpm -r build`
- [x] `pnpm test`
- [x] Smoke: fresh repo + no `OPENAI_API_KEY` + `unforgit embeddings backfill` + `unforgit doctor --json`
