### PR TITLE
fix: guard embedding provider compatibility

### DIFF
--- a/apps/cli/src/__tests__/commands/embeddings.test.ts
+++ b/apps/cli/src/__tests__/commands/embeddings.test.ts
@@ -154,6 +154,36 @@ describe("embeddings", () => {
     }
   });
 
+  it("backfill regenerates embeddings when the stored model is incompatible", async () => {
+    process.chdir(tmpDir.dir);
+    const memory = store.store({
+      orgId: "test-org",
+      repoId: "test-repo",
+      memoryType: "semantic",
+      text: "local provider should replace stale vectors",
+      tags: [],
+      visibility: "auto",
+    });
+    await store.storeEmbedding(memory.id, [0.1, 0.2, 0.3], "text-embedding-3-small");
+    store.close();
+
+    const result = await runCommand(["embeddings", "backfill", "--json", "--delay", "1"]);
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload).toMatchObject({
+      provider: "local",
+      model: "local-hash-multilingual-v1",
+      planned: 1,
+      processed: 1,
+      errors: 0,
+    });
+
+    store = new LocalStore(tmpDir.dbPath);
+    const embedding = store.getEmbedding(memory.id);
+    expect(embedding).toHaveLength(384);
+  });
+
   it("embeddings clear creates a recoverable backup by default", async () => {
     process.chdir(tmpDir.dir);
     const memory = store.store({

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -114,16 +114,22 @@ export const doctorCommand = new Command("doctor")
         });
 
         const stats = store.getEmbeddingStats(orgId, repoId);
+        const incompatibleOrMissing = store.getMemoriesWithoutEmbeddings(orgId, repoId, {
+          model: provider.model,
+          provider: provider.provider,
+          dimensions: provider.dimensions,
+        }).length;
         if (stats.total === 0) {
           results.push({ check: "embeddings", status: "ok", message: "No memories yet" });
-        } else if (stats.withoutEmbedding === 0) {
-          results.push({ check: "embeddings", status: "ok", message: `All ${stats.total} memories have embeddings` });
+        } else if (incompatibleOrMissing === 0) {
+          results.push({ check: "embeddings", status: "ok", message: `All ${stats.total} memories have compatible embeddings` });
         } else {
-          const pct = ((stats.withEmbedding / stats.total) * 100).toFixed(1);
+          const compatible = stats.total - incompatibleOrMissing;
+          const pct = ((compatible / stats.total) * 100).toFixed(1);
           results.push({
             check: "embeddings",
             status: "warn",
-            message: `${stats.withoutEmbedding}/${stats.total} memories lack embeddings (${pct}% coverage). Run 'unforgit embeddings backfill'`,
+            message: `${incompatibleOrMissing}/${stats.total} memories lack compatible embeddings for ${provider.provider}/${provider.model} (${pct}% coverage). Run 'unforgit embeddings backfill'`,
             fix: "Run 'unforgit embeddings backfill'.",
           });
         }

--- a/apps/cli/src/commands/embeddings.ts
+++ b/apps/cli/src/commands/embeddings.ts
@@ -97,7 +97,11 @@ embeddingsCommand
     const repoId = config.remote.repoId || "local";
 
     try {
-      const memories = store.getMemoriesWithoutEmbeddings(orgId, repoId);
+      const memories = store.getMemoriesWithoutEmbeddings(orgId, repoId, {
+        model: provider.model,
+        provider: provider.provider,
+        dimensions: provider.dimensions,
+      });
       const stats = store.getEmbeddingStats(orgId, repoId);
 
       if (isJsonMode() && opts.dryRun) {
@@ -171,7 +175,7 @@ embeddingsCommand
               const result = await generateEmbedding(memory.text, {
                 ...embeddingConfig,
               });
-              await store.storeEmbedding(memory.id, result.embedding, result.model);
+              await store.storeEmbedding(memory.id, result.embedding, result.model, result.provider);
               processed++;
               logger.progress(processed, memories.length, "embeddings");
             } catch (err) {

--- a/apps/website/app/docs/page.tsx
+++ b/apps/website/app/docs/page.tsx
@@ -263,7 +263,9 @@ $ unforgit add --template security "Never commit OAuth client secrets into repo 
             Embeddings are local-first. <UnforgitBrand /> can generate semantic
             recall vectors without <code>OPENAI_API_KEY</code>; OpenAI remains
             optional for teams that explicitly want cloud-backed embeddings or
-            LLM-based consolidation flows.
+            LLM-based consolidation flows. Backfill records provider, model, and
+            dimensions so switching providers safely regenerates incompatible
+            vectors instead of mixing them silently.
           </p>
           <div className="space-y-4">
             <Terminal

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ website/             # Public website and docs (Next.js)
 
 ## Semantic Search
 
-Unforgit uses local-first embeddings for semantic search, finding memories by meaning rather than just keywords without requiring cloud credentials. OpenAI embeddings remain available when explicitly configured.
+Unforgit uses local-first embeddings for semantic search, finding memories by meaning rather than just keywords without requiring cloud credentials. OpenAI embeddings remain available when explicitly configured. Stored vectors carry provider/model/dimension metadata, and backfill treats incompatible vectors as stale when the configured provider changes.
 
 The system uses a hybrid scoring approach with a bounded usage boost:
 - Semantic similarity (embeddings)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,7 +124,7 @@ Duplicate pending suggestions for the same type and memory IDs are skipped, keep
 
 ## Embeddings
 
-Embeddings are local-first. `unforgit embeddings backfill` works without `OPENAI_API_KEY` by using the configured `auto`/`local` provider. OpenAI is optional: use `--provider openai --model text-embedding-3-small` when you explicitly want cloud embeddings.
+Embeddings are local-first. `unforgit embeddings backfill` works without `OPENAI_API_KEY` by using the configured `auto`/`local` provider. OpenAI is optional: use `--provider openai --model text-embedding-3-small` when you explicitly want cloud embeddings. Backfill also checks provider/model/dimensions and regenerates stale vectors when you switch embedding providers.
 
 ```bash
 # Generate local embeddings for existing memories (no API key required)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ openaiApiKey: sk-your-api-key
 export OPENAI_API_KEY=sk-your-api-key
 ```
 
-When the key is not configured, Unforgit uses local embeddings by default. To force local-only behavior, set `embeddings.provider: local`. To disable embeddings entirely and use FTS-only recall, set `embeddings.provider: disabled` or `embeddings.enabled: false`.
+When the key is not configured, Unforgit uses local embeddings by default. To force local-only behavior, set `embeddings.provider: local`. To disable embeddings entirely and use FTS-only recall, set `embeddings.provider: disabled` or `embeddings.enabled: false`. If you change providers or models, `unforgit embeddings backfill` detects incompatible provider/model/dimension metadata and regenerates the affected vectors.
 
 ## YAML Configuration File
 

--- a/packages/db/src/local.ts
+++ b/packages/db/src/local.ts
@@ -34,6 +34,7 @@ import {
   generateEmbedding,
   serializeEmbedding,
   deserializeEmbedding,
+  getEmbeddingDimensions,
   cosineSimilarity,
   type EmbeddingConfig,
 } from "unforgit-core";
@@ -129,6 +130,8 @@ CREATE TABLE IF NOT EXISTS memory_embeddings (
   memory_id TEXT PRIMARY KEY REFERENCES memories(id) ON DELETE CASCADE,
   embedding BLOB NOT NULL,
   model TEXT NOT NULL,
+  provider TEXT,
+  dimensions INTEGER,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
@@ -339,9 +342,24 @@ export class LocalStore {
           memory_id TEXT PRIMARY KEY REFERENCES memories(id) ON DELETE CASCADE,
           embedding BLOB NOT NULL,
           model TEXT NOT NULL,
+          provider TEXT,
+          dimensions INTEGER,
           created_at TEXT NOT NULL DEFAULT (datetime('now'))
         );
       `);
+    }
+    const embeddingColumns = this.db
+      .prepare("PRAGMA table_info(memory_embeddings)")
+      .all() as Array<{ name: string }>;
+    const embeddingColumnNames = embeddingColumns.map((c) => c.name);
+    if (!embeddingColumnNames.includes("provider")) {
+      this.db.exec("ALTER TABLE memory_embeddings ADD COLUMN provider TEXT");
+    }
+    if (!embeddingColumnNames.includes("dimensions")) {
+      this.db.exec("ALTER TABLE memory_embeddings ADD COLUMN dimensions INTEGER");
+      this.db
+        .prepare("UPDATE memory_embeddings SET dimensions = length(embedding) / 4 WHERE dimensions IS NULL")
+        .run();
     }
 
     const usageTables = this.db
@@ -1770,17 +1788,19 @@ export class LocalStore {
   async storeEmbedding(
     memoryId: string,
     embedding: number[],
-    model: string
+    model: string,
+    provider?: string
   ): Promise<void> {
     const now = new Date().toISOString();
     const blob = serializeEmbedding(embedding);
+    const dimensions = embedding.length || getEmbeddingDimensions(model);
 
     this.db
       .prepare(
-        `INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding, model, created_at)
-         VALUES (?, ?, ?, ?)`
+        `INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding, model, provider, dimensions, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`
       )
-      .run(memoryId, blob, model, now);
+      .run(memoryId, blob, model, provider ?? null, dimensions, now);
   }
 
   async generateAndStoreEmbedding(
@@ -1790,7 +1810,7 @@ export class LocalStore {
   ): Promise<void> {
     try {
       const result = await generateEmbedding(text, config);
-      await this.storeEmbedding(memoryId, result.embedding, result.model);
+      await this.storeEmbedding(memoryId, result.embedding, result.model, result.provider);
     } catch (error) {
       console.error(`Failed to generate embedding for ${memoryId}:`, error);
     }
@@ -1814,15 +1834,18 @@ export class LocalStore {
 
   getAllEmbeddings(
     orgId: string,
-    repoId: string
+    repoId: string,
+    dimensions?: number
   ): Array<{ memoryId: string; embedding: number[] }> {
+    const dimensionClause = dimensions ? " AND e.dimensions = ?" : "";
+    const params = dimensions ? [orgId, repoId, dimensions] : [orgId, repoId];
     const rows = this.db
       .prepare(
         `SELECT e.memory_id, e.embedding FROM memory_embeddings e
          JOIN memories m ON e.memory_id = m.id
-         WHERE m.org_id = ? AND m.repo_id = ? AND m.status = 'active'`
+         WHERE m.org_id = ? AND m.repo_id = ? AND m.status = 'active'${dimensionClause}`
       )
-      .all(orgId, repoId) as Array<{ memory_id: string; embedding: Buffer }>;
+      .all(...params) as Array<{ memory_id: string; embedding: Buffer }>;
 
     return rows.map((row) => ({
       memoryId: row.memory_id,
@@ -1830,14 +1853,33 @@ export class LocalStore {
     }));
   }
 
-  getMemoriesWithoutEmbeddings(orgId: string, repoId: string): Memory[] {
+  getMemoriesWithoutEmbeddings(
+    orgId: string,
+    repoId: string,
+    expected?: { model?: string; provider?: string; dimensions?: number }
+  ): Memory[] {
+    const compatibilityClauses: string[] = ["e.memory_id IS NULL"];
+    const params: unknown[] = [orgId, repoId];
+    if (expected?.model) {
+      compatibilityClauses.push("e.model != ?");
+      params.push(expected.model);
+    }
+    if (expected?.provider) {
+      compatibilityClauses.push("e.provider IS NULL OR e.provider != ?");
+      params.push(expected.provider);
+    }
+    if (expected?.dimensions) {
+      compatibilityClauses.push("e.dimensions IS NULL OR e.dimensions != ?");
+      params.push(expected.dimensions);
+    }
     const rows = this.db
       .prepare(
         `SELECT m.* FROM memories m
          LEFT JOIN memory_embeddings e ON m.id = e.memory_id
-         WHERE m.org_id = ? AND m.repo_id = ? AND m.status = 'active' AND e.memory_id IS NULL`
+         WHERE m.org_id = ? AND m.repo_id = ? AND m.status = 'active'
+           AND (${compatibilityClauses.map((clause) => `(${clause})`).join(" OR ")})`
       )
-      .all(orgId, repoId) as Array<Record<string, unknown>>;
+      .all(...params) as Array<Record<string, unknown>>;
 
     return rows.map(rowToMemory);
   }
@@ -1852,7 +1894,7 @@ export class LocalStore {
       return ftsResults;
     }
 
-    const allEmbeddings = this.getAllEmbeddings(query.orgId, query.repoId);
+    const allEmbeddings = this.getAllEmbeddings(query.orgId, query.repoId, queryEmbedding.length);
 
     if (allEmbeddings.length === 0) {
       return ftsResults;


### PR DESCRIPTION
## Summary
- Store embedding provider and dimensions alongside model metadata in local SQLite embeddings.
- Treat missing/incompatible provider, model, or dimensions as stale during `unforgit embeddings backfill`.
- Filter embedding recall by query-vector dimensions so mixed legacy vectors cannot crash or skew recall.
- Update `doctor` to report compatible embedding coverage for the configured provider.
- Update CLI/config/architecture/website docs for provider compatibility behavior.

Part of #41. Keeps #43 blocked until the remaining v0.7 scope is accepted or completed.

## Test plan
- [x] `pnpm vitest run apps/cli/src/__tests__/commands/embeddings.test.ts -t "stored model is incompatible"` (red before implementation, green after)
- [x] `pnpm vitest run apps/cli/src/__tests__/commands/embeddings.test.ts apps/cli/src/__tests__/commands/doctor.test.ts`
- [x] `pnpm test`
- [x] `pnpm -r build`
