### PR TITLE
fix: clarify local memory versus remote API diagnostics

### DIFF
--- a/apps/cli/src/__tests__/commands/doctor.test.ts
+++ b/apps/cli/src/__tests__/commands/doctor.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import YAML from "yaml";
 import { createTempDataDir, runCommand } from "../helpers.js";
 import { LocalStore } from "unforgit-db";
 
@@ -70,5 +72,45 @@ describe("doctor command", () => {
       ]),
     );
     expect(result.stdout).not.toContain(process.env.OPENAI_API_KEY ?? "__missing_openai_key__");
+  });
+
+  it("reports localhost remote API offline separately from local memory/provider health", async () => {
+    tmp = createTempDataDir({ remote: { url: "http://127.0.0.1:9" } });
+    process.chdir(tmp.dir);
+
+    const config = YAML.parse(fs.readFileSync(tmp.configPath, "utf-8"));
+    config.sync.enabled = false;
+    fs.writeFileSync(tmp.configPath, YAML.stringify(config), "utf-8");
+
+    const store = new LocalStore(tmp.dbPath);
+    try {
+      const memory = store.store({
+        orgId: "test-org",
+        repoId: "test-repo",
+        scopeType: "repo",
+        memoryType: "semantic",
+        visibility: "private",
+        text: "Local provider should remain healthy when remote API is offline",
+        tags: [],
+      });
+      await store.storeEmbedding(memory.id, [0.1, 0.2, 0.3], "local-hash-multilingual-v1", "local");
+    } finally {
+      store.close();
+    }
+
+    const result = await runCommand(["doctor", "--json"]);
+
+    expect(result.exitCode).toBe(1);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ check: "embedding-provider", status: "ok" }),
+        expect.objectContaining({ check: "openai", status: "ok" }),
+        expect.objectContaining({ check: "remote", status: "error" }),
+      ]),
+    );
+    const remote = payload.results.find((r: { check: string }) => r.check === "remote");
+    expect(remote.message).toContain("Local memory and local embeddings still work");
+    expect(remote.fix).toContain("remote.url points to localhost");
   });
 });

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -220,11 +220,16 @@ export const doctorCommand = new Command("doctor")
             });
           }
         } catch (err) {
+          const localhostRemote = isLocalhostUrl(config.remote.url);
           results.push({
             check: "remote",
             status: "error",
-            message: `Cannot connect to ${config.remote.url}: ${err instanceof Error ? err.message : err}`,
-            fix: "Start the Unforgit API server or update remote.url in unforgit.yaml.",
+            message: localhostRemote
+              ? `Cannot connect to local remote API at ${config.remote.url}: ${err instanceof Error ? err.message : err}. Local memory and local embeddings still work; only remote sync is unavailable.`
+              : `Cannot connect to ${config.remote.url}: ${err instanceof Error ? err.message : err}`,
+            fix: localhostRemote
+              ? "remote.url points to localhost. Start the Unforgit API server on this machine/port, update remote.url, or disable sync if this repository is intentionally local-only."
+              : "Start the Unforgit API server or update remote.url in unforgit.yaml.",
           });
         }
       } else {
@@ -284,6 +289,15 @@ function summarize(results: DiagnosticResult[]): DoctorSummary {
 
 function buildPayload(results: DiagnosticResult[]): { summary: DoctorSummary; results: DiagnosticResult[] } {
   return { summary: summarize(results), results };
+}
+
+function isLocalhostUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return ["localhost", "127.0.0.1", "::1", "[::1]"].includes(url.hostname);
+  } catch {
+    return false;
+  }
 }
 
 function exitForResults(results: DiagnosticResult[]): void {

--- a/apps/website/app/docs/mcp/page.tsx
+++ b/apps/website/app/docs/mcp/page.tsx
@@ -629,7 +629,9 @@ UNFORGIT_API_KEY=hk_your_api_key`}
         <Subsection id="mcp-remote-config" title="Configure the Remote URL">
           <p className="text-sm text-dracula-foreground/70 mb-4">
             Point your local <UnforgitBrand /> at a remote API server for team-shared
-            memory, hybrid recall, and server-side AI features.
+            memory, remote recall, and server-side AI features. The remote API is
+            only needed for sync/remote commands; local SQLite memory and MCP tools
+            continue to work if this endpoint is offline.
           </p>
           <div className="space-y-4">
             <Terminal

--- a/apps/website/app/docs/page.tsx
+++ b/apps/website/app/docs/page.tsx
@@ -235,7 +235,7 @@ $ unforgit add --template security "Never commit OAuth client secrets into repo 
             <ul className="text-sm text-dracula-foreground/70 space-y-2">
               <li>
                 Local recall uses SQLite FTS5 with a fallback string search when
-                needed.
+                needed. Local embeddings can run without cloud credentials.
               </li>
               <li>
                 The CLI merges local recall with remote recall and re-ranks the
@@ -243,7 +243,9 @@ $ unforgit add --template security "Never commit OAuth client secrets into repo 
               </li>
               <li>
                 Remote <code>/v1/recall</code> becomes hybrid when the server
-                has <code>OPENAI_API_KEY</code> configured.
+                has <code>OPENAI_API_KEY</code> configured. If the remote API is
+                offline, local recall and MCP tools still work; only remote sync
+                and remote recall are unavailable.
               </li>
               <li>
                 Ranking factors include text match, embedding similarity when

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,7 +73,7 @@ unforgit add --list-templates
 
 ## Doctor (Diagnostics)
 
-Use `doctor` before troubleshooting sync, embeddings, local database, or remote API issues. It validates initialization, config shape and permissions, deprecated secret-bearing config keys, SQLite access, memory counts, embedding coverage, tombstone/sync state, remote reachability, and required environment variables without printing secret values.
+Use `doctor` before troubleshooting sync, embeddings, local database, or remote API issues. It validates initialization, config shape and permissions, deprecated secret-bearing config keys, SQLite access, memory counts, embedding coverage, tombstone/sync state, remote reachability, and required environment variables without printing secret values. Local memory, MCP tools, and the remote API are separate: if a localhost `remote.url` is offline, `doctor` reports remote sync as unavailable while making clear that local memory and local embeddings still work.
 
 ```bash
 # Human-readable diagnostics with suggested fixes

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -119,7 +119,7 @@ Restart your IDE after adding the MCP config.
 | `unforgit_notifications` | Get pending notifications | - |
 | `unforgit_templates` | List available memory templates | - |
 
-The MCP server works with the local SQLite store only (no remote dependency). It automatically discovers the `.unforgit/unforgit.yaml` config by walking up the filesystem from the working directory, and loads environment variables from the repo's `.env` file.
+The MCP server works with the local SQLite store only (no remote dependency). It automatically discovers the `.unforgit/unforgit.yaml` config by walking up the filesystem from the working directory, and loads environment variables from the repo's `.env` file. A broken or offline `remote.url` affects CLI/API sync commands such as `push` and `pull`, but it does not stop local MCP recall/add tools from working.
 
 ## IDE Rules
 


### PR DESCRIPTION
## Summary
- Clarifies `unforgit doctor` output when `remote.url` points to localhost but the remote API is offline.
- Makes the remote failure message explicit that local memory and local embeddings still work, while remote sync is unavailable.
- Adds regression coverage for localhost remote API failure with local provider health remaining OK.
- Updates CLI/MCP docs and website docs to separate local SQLite/MCP behavior from remote API sync behavior.

Part of #41. Keeps #43 blocked until the remaining v0.7 scope is accepted or completed.

## Test plan
- [x] `pnpm vitest run apps/cli/src/__tests__/commands/doctor.test.ts -t "localhost remote API offline"` (red before implementation, green after)
- [x] `pnpm vitest run apps/cli/src/__tests__/commands/doctor.test.ts`
- [x] `pnpm test`
- [x] `pnpm -r build`
