### PR TITLE
fix(auth): harden OAuth state validation

### DIFF
--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -1,7 +1,7 @@
 import Fastify from "fastify";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RemoteStore } from "unforgit-db";
-import { authRoutes, parseCookieHeader } from "../routes/auth.js";
+import { authRoutes } from "../routes/auth.js";
 
 async function buildApp() {
   const app = Fastify();
@@ -13,31 +13,30 @@ describe("auth routes", () => {
   afterEach(() => {
     delete process.env.GITHUB_CLIENT_ID;
     delete process.env.GITHUB_CLIENT_SECRET;
+    delete process.env.JWT_SECRET;
     vi.restoreAllMocks();
   });
 
-  it("sets an HttpOnly OAuth state cookie that matches the GitHub redirect state", async () => {
+  it("redirects with a signed OAuth state token instead of a state cookie", async () => {
     process.env.GITHUB_CLIENT_ID = "client-id";
+    process.env.GITHUB_CLIENT_SECRET = "client-secret";
     const app = await buildApp();
 
     const response = await app.inject({ method: "GET", url: "/v1/auth/github" });
 
     expect(response.statusCode).toBe(302);
     const location = response.headers.location;
-    const setCookie = response.headers["set-cookie"];
     expect(location).toEqual(expect.stringContaining("https://github.com/login/oauth/authorize"));
-    expect(setCookie).toEqual(expect.stringContaining("unforgit_oauth_state="));
-    expect(setCookie).toEqual(expect.stringContaining("HttpOnly"));
-    expect(setCookie).toEqual(expect.stringContaining("SameSite=Lax"));
+    expect(response.headers["set-cookie"]).toBeUndefined();
 
     const state = new URL(location as string).searchParams.get("state");
-    const cookies = parseCookieHeader((setCookie as string).split(";")[0]);
-    expect(cookies.unforgit_oauth_state).toBe(state);
+    expect(state).toMatch(/^eyJ/);
+    expect(state?.split(".")).toHaveLength(3);
 
     await app.close();
   });
 
-  it("rejects GitHub OAuth callbacks without a matching state cookie", async () => {
+  it("rejects GitHub OAuth callbacks without a valid signed state", async () => {
     process.env.GITHUB_CLIENT_ID = "client-id";
     process.env.GITHUB_CLIENT_SECRET = "client-secret";
     const fetchSpy = vi.spyOn(globalThis, "fetch");
@@ -45,13 +44,12 @@ describe("auth routes", () => {
 
     const response = await app.inject({
       method: "GET",
-      url: "/v1/auth/github/callback?code=abc&state=state-from-query",
-      headers: { cookie: "unforgit_oauth_state=different-state" },
+      url: "/v1/auth/github/callback?code=abc&state=tampered-state",
     });
 
     expect(response.statusCode).toBe(400);
     expect(response.json()).toMatchObject({ message: "Invalid OAuth state" });
-    expect(response.headers["set-cookie"]).toEqual(expect.stringContaining("Max-Age=0"));
+    expect(response.headers["set-cookie"]).toBeUndefined();
     expect(fetchSpy).not.toHaveBeenCalled();
 
     await app.close();

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -29,58 +29,31 @@ interface CallbackQuery {
   state?: string;
 }
 
-const OAUTH_STATE_COOKIE = "unforgit_oauth_state";
-
-function serializeCookie(
-  name: string,
-  value: string,
-  options: { maxAge?: number; httpOnly?: boolean; sameSite?: "Lax" | "Strict" | "None"; secure?: boolean; path?: string } = {},
-): string {
-  const parts = [`${name}=${encodeURIComponent(value)}`];
-  if (options.maxAge !== undefined) parts.push(`Max-Age=${options.maxAge}`);
-  if (options.path) parts.push(`Path=${options.path}`);
-  if (options.httpOnly) parts.push("HttpOnly");
-  if (options.sameSite) parts.push(`SameSite=${options.sameSite}`);
-  if (options.secure) parts.push("Secure");
-  return parts.join("; ");
-}
-
-export function parseCookieHeader(header: string | undefined): Record<string, string> {
-  const cookies: Record<string, string> = {};
-  if (!header) return cookies;
-
-  for (const part of header.split(";")) {
-    const [rawName, ...rawValue] = part.trim().split("=");
-    if (!rawName || rawValue.length === 0) continue;
-
-    try {
-      cookies[rawName] = decodeURIComponent(rawValue.join("="));
-    } catch {
-      cookies[rawName] = rawValue.join("=");
-    }
+function getOAuthStateSecret(): Uint8Array {
+  const secret = process.env.GITHUB_CLIENT_SECRET || process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error("GITHUB_CLIENT_SECRET or JWT_SECRET environment variable is required");
   }
-
-  return cookies;
+  return new TextEncoder().encode(secret);
 }
 
-function getOAuthStateCookie(state: string, secure: boolean): string {
-  return serializeCookie(OAUTH_STATE_COOKIE, state, {
-    httpOnly: true,
-    sameSite: "Lax",
-    secure,
-    path: "/v1/auth/github/callback",
-    maxAge: 600,
-  });
+async function createOAuthState(): Promise<string> {
+  return new SignJWT({ nonce: crypto.randomUUID() })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("10m")
+    .sign(getOAuthStateSecret());
 }
 
-function clearOAuthStateCookie(secure: boolean): string {
-  return serializeCookie(OAUTH_STATE_COOKIE, "", {
-    httpOnly: true,
-    sameSite: "Lax",
-    secure,
-    path: "/v1/auth/github/callback",
-    maxAge: 0,
-  });
+async function verifyOAuthState(state: string | undefined): Promise<boolean> {
+  if (!state) return false;
+
+  try {
+    await jwtVerify(state, getOAuthStateSecret());
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function getJwtSecret(): Uint8Array {
@@ -217,50 +190,50 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
   app,
   { store }
 ) => {
-  app.get("/v1/auth/github", async (request, reply) => {
-    const clientId = process.env.GITHUB_CLIENT_ID;
-    const callbackUrl = process.env.GITHUB_CALLBACK_URL;
+  app.get(
+    "/v1/auth/github",
+    { config: { rateLimit: { max: 10, timeWindow: "1 minute" } } },
+    async (_request, reply) => {
+      const clientId = process.env.GITHUB_CLIENT_ID;
+      const clientSecret = process.env.GITHUB_CLIENT_SECRET || process.env.JWT_SECRET;
+      const callbackUrl = process.env.GITHUB_CALLBACK_URL;
 
-    if (!clientId) {
-      return reply.status(503).send({
-        error: "Service Unavailable",
-        message: "GitHub OAuth is not configured",
-      });
+      if (!clientId || !clientSecret) {
+        return reply.status(503).send({
+          error: "Service Unavailable",
+          message: "GitHub OAuth is not configured",
+        });
+      }
+
+      const state = await createOAuthState();
+      const scope = "read:user,user:email,repo";
+
+      const authUrl = new URL("https://github.com/login/oauth/authorize");
+      authUrl.searchParams.set("client_id", clientId);
+      authUrl.searchParams.set("scope", scope);
+      authUrl.searchParams.set("state", state);
+      if (callbackUrl) {
+        authUrl.searchParams.set("redirect_uri", callbackUrl);
+      }
+
+      return reply.redirect(authUrl.toString());
     }
-
-    const state = crypto.randomUUID();
-    const scope = "read:user,user:email,repo";
-    const secureCookie = request.protocol === "https";
-
-    const authUrl = new URL("https://github.com/login/oauth/authorize");
-    authUrl.searchParams.set("client_id", clientId);
-    authUrl.searchParams.set("scope", scope);
-    authUrl.searchParams.set("state", state);
-    if (callbackUrl) {
-      authUrl.searchParams.set("redirect_uri", callbackUrl);
-    }
-
-    reply.header("Set-Cookie", getOAuthStateCookie(state, secureCookie));
-    return reply.redirect(authUrl.toString());
-  });
+  );
 
   app.get<{ Querystring: CallbackQuery }>(
     "/v1/auth/github/callback",
+    { config: { rateLimit: { max: 10, timeWindow: "1 minute" } } },
     async (request, reply) => {
       const { code, state } = request.query;
-      const secureCookie = request.protocol === "https";
-      const expectedState = parseCookieHeader(request.headers.cookie)[OAUTH_STATE_COOKIE];
 
       if (!code) {
-        reply.header("Set-Cookie", clearOAuthStateCookie(secureCookie));
         return reply.status(400).send({
           error: "Bad Request",
           message: "Missing code parameter",
         });
       }
 
-      if (!state || !expectedState || state !== expectedState) {
-        reply.header("Set-Cookie", clearOAuthStateCookie(secureCookie));
+      if (!(await verifyOAuthState(state))) {
         return reply.status(400).send({
           error: "Bad Request",
           message: "Invalid OAuth state",
@@ -298,14 +271,12 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         });
 
         const adminUrl = process.env.ADMIN_DASHBOARD_URL || "http://localhost:3939";
-        reply.header("Set-Cookie", clearOAuthStateCookie(secureCookie));
         return reply.redirect(`${adminUrl}/auth/callback?token=${token}`);
       } catch (error) {
         const message = error instanceof Error ? error.message : "Unknown error";
         app.log.error(`GitHub OAuth error: ${message}`);
 
         const adminUrl = process.env.ADMIN_DASHBOARD_URL || "http://localhost:3939";
-        reply.header("Set-Cookie", clearOAuthStateCookie(secureCookie));
         return reply.redirect(`${adminUrl}/auth/callback?error=${encodeURIComponent(message)}`);
       }
     }


### PR DESCRIPTION
## Summary
- replace the OAuth state cookie with a short-lived signed OAuth state JWT
- validate callback state server-side before exchanging GitHub OAuth codes
- add rate limiting to the GitHub OAuth start and callback routes
- add regression coverage for no state cookie and tampered state rejection

## Verification
- pnpm audit --json
- pnpm lint
- pnpm test -- --run apps/api/src/__tests__/auth.test.ts (Vitest ran the full suite: 35 files / 186 tests)
- pnpm install --frozen-lockfile
- DATABASE_URL=... pnpm db:generate
- DATABASE_URL=... pnpm build
- pnpm smoke:cli

Docker rebuild attempted, but this runner does not have docker installed.