### PR TITLE
fix(api): reject malformed admin bearer headers

### DIFF
--- a/apps/api/src/__tests__/admin-auth.test.ts
+++ b/apps/api/src/__tests__/admin-auth.test.ts
@@ -1,0 +1,54 @@
+import Fastify from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RemoteStore } from "unforgit-db";
+import { SignJWT } from "jose";
+import { adminRoutes } from "../routes/admin.js";
+
+function buildStore() {
+  return {
+    listApiKeysWithUsers: vi.fn(),
+  } as unknown as RemoteStore & { listApiKeysWithUsers: ReturnType<typeof vi.fn> };
+}
+
+async function buildAdminApp(store: RemoteStore) {
+  const app = Fastify();
+  await app.register(adminRoutes, { store });
+  return app;
+}
+
+async function signAdminToken(): Promise<string> {
+  return new SignJWT({ isAdmin: true })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .sign(new TextEncoder().encode(process.env.JWT_SECRET));
+}
+
+describe("admin auth", () => {
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+    vi.restoreAllMocks();
+  });
+
+  it("rejects bearer authorization headers with extra credentials", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    const store = buildStore();
+    const token = await signAdminToken();
+    const app = await buildAdminApp(store);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/admin/api-keys",
+      headers: {
+        authorization: `Bearer ${token} injected-token`,
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toMatchObject({
+      message: "Invalid Authorization header format",
+    });
+    expect(store.listApiKeysWithUsers).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -79,9 +79,9 @@ async function adminAuthPreHandler(
     return;
   }
 
-  const [scheme, token] = authHeader.split(" ");
+  const tokenMatch = /^Bearer\s+(\S+)$/i.exec(authHeader.trim());
 
-  if (scheme?.toLowerCase() !== "bearer" || !token) {
+  if (!tokenMatch) {
     reply.status(401).send({
       error: "Unauthorized",
       message: "Invalid Authorization header format",
@@ -89,7 +89,7 @@ async function adminAuthPreHandler(
     return;
   }
 
-  const valid = await verifyAdminToken(token);
+  const valid = await verifyAdminToken(tokenMatch[1]);
 
   if (!valid) {
     reply


### PR DESCRIPTION
## Summary
- Reject malformed admin `Authorization` headers that include extra credentials after the bearer token
- Add regression coverage for the admin API key listing route to ensure malformed headers are rejected before store access

## Verification
- `pnpm exec vitest run apps/api/src/__tests__/admin-auth.test.ts`
- `pnpm test`

## Safety
- Auth parsing hardening only
- No data migration, deploy, or secret changes
