### PR TITLE
feat(cli): add Kilo Code integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ unforgit init --ide cline       # Cline workspace rules + MCP
 unforgit init --ide roo-code    # Roo Code project rules + MCP
 unforgit init --ide codex       # Codex AGENTS.md + MCP config
 unforgit init --ide opencode    # OpenCode AGENTS.md + MCP config
+unforgit init --ide kilo-code   # Kilo Code AGENTS.md + MCP config
 unforgit init --ide all         # All supported project integrations
 ```
 

--- a/apps/cli/src/__tests__/ide-integration.test.ts
+++ b/apps/cli/src/__tests__/ide-integration.test.ts
@@ -95,6 +95,7 @@ describe("IDE integration setup", () => {
   it("accepts common aliases for CLI IDE setup", () => {
     expect(parseIdeOption("claude-code")).toEqual(["claude"]);
     expect(parseIdeOption("claude_code,copilot")).toEqual(["claude", "vscode"]);
+    expect(parseIdeOption("kilo-code,kilocode")).toEqual(["kilo", "kilo"]);
   });
 
   it("creates Cline project MCP config and workspace rules", () => {
@@ -147,6 +148,18 @@ describe("IDE integration setup", () => {
       command: ["unforgit-mcp"],
       enabled: true,
     });
+    const agents = fs.readFileSync(path.join(dir, "AGENTS.md"), "utf-8");
+    expect(agents).toContain("Unforgit Memory Integration");
+  });
+
+  it("creates Kilo Code project MCP config and AGENTS instructions", () => {
+    const dir = makeTempDir();
+
+    const [result] = setupIdes(dir, ["kilo"]);
+
+    expect(result.ide).toBe("kilo");
+    const mcp = JSON.parse(fs.readFileSync(path.join(dir, ".kilocode", "mcp.json"), "utf-8"));
+    expect(mcp.mcpServers.unforgit).toEqual({ command: "unforgit-mcp", args: [] });
     const agents = fs.readFileSync(path.join(dir, "AGENTS.md"), "utf-8");
     expect(agents).toContain("Unforgit Memory Integration");
   });

--- a/apps/cli/src/ide-integration.ts
+++ b/apps/cli/src/ide-integration.ts
@@ -10,7 +10,8 @@ export type IdeName =
   | "cline"
   | "roo"
   | "codex"
-  | "opencode";
+  | "opencode"
+  | "kilo";
 
 export const ALL_IDE_NAMES: IdeName[] = [
   "cursor",
@@ -21,6 +22,7 @@ export const ALL_IDE_NAMES: IdeName[] = [
   "roo",
   "codex",
   "opencode",
+  "kilo",
 ];
 
 const UNFORGIT_MARKER = "Unforgit Memory Integration";
@@ -315,6 +317,17 @@ function setupOpenCode(cwd: string): IdeSetupResult {
   return { ide: "opencode", rules, mcp };
 }
 
+// --- Kilo Code ---
+
+function setupKilo(cwd: string): IdeSetupResult {
+  const rules = appendOrCreateMarkdown(path.join(cwd, "AGENTS.md"), MEMORY_INSTRUCTIONS);
+  const mcp = upsertJsonMcp(path.join(cwd, ".kilocode", "mcp.json"), "mcpServers", {
+    command: "unforgit-mcp",
+    args: [],
+  });
+  return { ide: "kilo", rules, mcp };
+}
+
 // --- Detection ---
 
 const IDE_INDICATORS: Record<IdeName, string[]> = {
@@ -326,6 +339,7 @@ const IDE_INDICATORS: Record<IdeName, string[]> = {
   roo: [".roo", ".roorules"],
   codex: [".codex"],
   opencode: ["opencode.json", ".opencode"],
+  kilo: [".kilocode", "kilo.json", "kilo.jsonc", ".kilo"],
 };
 
 export function detectIdes(cwd: string): IdeName[] {
@@ -350,6 +364,7 @@ const IDE_HANDLERS: Record<IdeName, (cwd: string) => IdeSetupResult> = {
   roo: setupRoo,
   codex: setupCodex,
   opencode: setupOpenCode,
+  kilo: setupKilo,
 };
 
 const IDE_LABELS: Record<IdeName, string> = {
@@ -361,6 +376,7 @@ const IDE_LABELS: Record<IdeName, string> = {
   roo: "Roo Code",
   codex: "Codex CLI",
   opencode: "OpenCode",
+  kilo: "Kilo Code",
 };
 
 export function setupIdes(cwd: string, ides: IdeName[]): IdeSetupResult[] {
@@ -405,6 +421,8 @@ const IDE_ALIASES: Record<string, IdeName> = {
   "roo-code": "roo",
   open_code: "opencode",
   "open-code": "opencode",
+  kilocode: "kilo",
+  "kilo-code": "kilo",
 };
 
 export function parseIdeOption(value: string): IdeName[] {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,7 +8,7 @@ unforgit init
 
 Creates `.unforgit/` with `local.db` and `unforgit.yaml`, plus IDE-specific integration files. The org and repo are auto-detected from the git remote (`origin`). You can override with `--org-id` and `--repo-id` if needed.
 
-By default, `unforgit init` auto-detects which IDEs are present in the project (Cursor, Claude Code, VS Code, Windsurf, Cline, Roo Code, Codex CLI, OpenCode) and creates the appropriate rules and MCP config files for each. You can control this with `--ide`:
+By default, `unforgit init` auto-detects which IDEs are present in the project (Cursor, Claude Code, VS Code, Windsurf, Cline, Roo Code, Codex CLI, OpenCode, Kilo Code) and creates the appropriate rules and MCP config files for each. You can control this with `--ide`:
 
 ```bash
 unforgit init --ide cursor           # Cursor only
@@ -28,6 +28,7 @@ unforgit init --no-ide               # skip all IDE integration
 | Roo Code | `.roo/rules/unforgit-memory.md` | `.roo/mcp.json` |
 | Codex CLI | `AGENTS.md` | `.codex/config.toml` |
 | OpenCode | `AGENTS.md` | `opencode.json` |
+| Kilo Code | `AGENTS.md` | `.kilocode/mcp.json` |
 
 ## Add Memories
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -46,6 +46,7 @@ unforgit init --no-ide               # skip IDE integration
 | **Roo Code** | `.roo/rules/unforgit-memory.md` | `.roo/mcp.json` |
 | **Codex CLI** | `AGENTS.md` | `.codex/config.toml` |
 | **OpenCode** | `AGENTS.md` | `opencode.json` |
+| **Kilo Code** | `AGENTS.md` | `.kilocode/mcp.json` |
 
 ### Project-level vs global config
 
@@ -119,7 +120,7 @@ Example for VS Code (`.vscode/mcp.json`):
 }
 ```
 
-Example for Cline (`.cline/mcp.json`) and Roo Code (`.roo/mcp.json`):
+Example for Cline (`.cline/mcp.json`), Roo Code (`.roo/mcp.json`), and Kilo Code (`.kilocode/mcp.json`):
 
 ```json
 {
@@ -207,5 +208,6 @@ This makes the expected Hermes/agent provider behavior explicit: local memory re
 | Roo Code | `.roo/rules/unforgit-memory.md` |
 | Codex CLI | `AGENTS.md` (appended) |
 | OpenCode | `AGENTS.md` (appended) |
+| Kilo Code | `AGENTS.md` (appended) |
 
 For IDEs that use shared files (like `CLAUDE.md`), `unforgit init` safely appends the memory instructions without overwriting existing content.

--- a/llms-install.md
+++ b/llms-install.md
@@ -8,7 +8,7 @@ Unforgit is a Git-backed memory system for AI coding agents. The published `unfo
 
 - `unforgit` — CLI for initializing and managing repository memory.
 - `unforgit-mcp` — MCP stdio server for durable memory tools.
-- Agent/IDE setup helpers for Claude Code, Cursor, VS Code/Copilot, Windsurf, Cline, Roo Code, Codex CLI, and OpenCode.
+- Agent/IDE setup helpers for Claude Code, Cursor, VS Code/Copilot, Windsurf, Cline, Roo Code, Codex CLI, OpenCode, and Kilo Code.
 
 ## Requirements
 
@@ -50,6 +50,7 @@ unforgit init --ide windsurf    # Windsurf rules + MCP config
 unforgit init --ide claude-code # Claude Code project files
 unforgit init --ide codex       # Codex AGENTS.md + MCP config
 unforgit init --ide opencode    # OpenCode AGENTS.md + MCP config
+unforgit init --ide kilo-code   # Kilo Code AGENTS.md + MCP config
 unforgit init --ide all         # all supported project integrations
 ```
 


### PR DESCRIPTION
## Summary

- Add `kilo` / `kilo-code` as a supported `unforgit init --ide` target
- Generate Kilo Code project MCP config at `.kilocode/mcp.json`
- Reuse `AGENTS.md` for Kilo Code memory instructions
- Document Kilo Code in the README, MCP docs, CLI docs, and agent install guide

## Test Plan

- [x] RED: `pnpm vitest run apps/cli/src/__tests__/ide-integration.test.ts` failed before implementation for missing `kilo` support
- [x] `pnpm vitest run apps/cli/src/__tests__/ide-integration.test.ts`
- [x] `pnpm test`
- [x] `pnpm lint` (0 errors; existing warnings only)
- [x] `pnpm build`
- [x] Smoke: `node apps/cli/dist/index.js init --ide kilo-code` in a temp git repo creates `AGENTS.md` and `.kilocode/mcp.json`
