### PR TITLE
fix(docker): pin compatible pnpm version

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.title="unforgit-admin"
 FROM base AS builder
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.28.1 --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY tsconfig.base.json ./

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.title="unforgit-api"
 
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.28.1 --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY prisma ./prisma/
@@ -42,7 +42,7 @@ FROM node:20-alpine AS runner
 
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.28.1 --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY prisma ./prisma/


### PR DESCRIPTION
## Summary
- pin API and admin Docker builds to the repository's declared pnpm 10.28.1
- prevent `pnpm@latest` from silently selecting pnpm 11, which requires Node >=22.13 and breaks the Node 20 API image
- keep container installs aligned with `packageManager` and CI

## Verification
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `pnpm lint` (passes with 21 existing warnings)
- `pnpm test` (46 files, 231 tests)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`
- pnpm 11 bulk advisory audit: no known vulnerabilities

Docker Compose rebuild was attempted but the cron user cannot access `/var/run/docker.sock` (permission denied).
