### PR TITLE
fix(deps): patch brace expansion memory DoS

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.28.1 --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches/
 COPY tsconfig.base.json ./
 
 COPY packages/shared/package.json packages/shared/

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.28.1 --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches/
 COPY prisma ./prisma/
 COPY prisma.config.ts ./
 COPY tsconfig.base.json ./
@@ -45,6 +46,7 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.28.1 --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches/
 COPY prisma ./prisma/
 COPY prisma.config.ts ./
 

--- a/package.json
+++ b/package.json
@@ -62,14 +62,16 @@
       "picomatch@>=4.0.0 <4.0.4": "4.0.4",
       "postcss@<8.5.18": "8.5.18",
       "qs@>=6.11.1 <=6.15.1": "6.15.2",
-      "brace-expansion@<1.1.16": "1.1.16",
-      "brace-expansion@>=3.0.0 <5.0.8": "5.0.8",
+      "brace-expansion@<5.0.8": "5.0.8",
       "valibot@<=1.4.1": "1.4.2",
       "js-yaml@>=4.0.0 <4.3.0": "4.3.0",
       "body-parser@>=2.0.0 <2.3.0": "2.3.0",
       "@hono/node-server@<2.0.10": "2.0.10",
       "esbuild@>=0.17.0 <0.28.1": "0.28.1",
       "@babel/core@<=7.29.0": "7.29.7"
+    },
+    "patchedDependencies": {
+      "minimatch@3.1.5": "patches/minimatch@3.1.5.patch"
     }
   },
   "dependencies": {

--- a/patches/minimatch@3.1.5.patch
+++ b/patches/minimatch@3.1.5.patch
@@ -1,0 +1,17 @@
+diff --git a/minimatch.js b/minimatch.js
+index 2e4a058a130dceebf83a7bd435f5d22b765ac836..c63d88c2b8ce1eb9a3e26a716028f560e9490ea9 100644
+--- a/minimatch.js
++++ b/minimatch.js
+@@ -7,7 +7,11 @@ var path = (function () { try { return require('path') } catch (e) {}}()) || {
+ minimatch.sep = path.sep
+ 
+ var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
+-var expand = require('brace-expansion')
++var braceExpansion = require('brace-expansion')
++// brace-expansion >=5 exports expand as a named export.
++var expand = typeof braceExpansion === 'function'
++  ? braceExpansion
++  : braceExpansion.expand
+ 
+ var plTypes = {
+   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,14 +18,18 @@ overrides:
   picomatch@>=4.0.0 <4.0.4: 4.0.4
   postcss@<8.5.18: 8.5.18
   qs@>=6.11.1 <=6.15.1: 6.15.2
-  brace-expansion@<1.1.16: 1.1.16
-  brace-expansion@>=3.0.0 <5.0.8: 5.0.8
+  brace-expansion@<5.0.8: 5.0.8
   valibot@<=1.4.1: 1.4.2
   js-yaml@>=4.0.0 <4.3.0: 4.3.0
   body-parser@>=2.0.0 <2.3.0: 2.3.0
   '@hono/node-server@<2.0.10': 2.0.10
   esbuild@>=0.17.0 <0.28.1: 0.28.1
   '@babel/core@<=7.29.0': 7.29.7
+
+patchedDependencies:
+  minimatch@3.1.5:
+    hash: 1569eeafd2181ce206249d08003a6b577ec82e1f949cc16af59bfcea6d80a5d7
+    path: patches/minimatch@3.1.5.patch
 
 importers:
 
@@ -2471,9 +2475,6 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2505,9 +2506,6 @@ packages:
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
-
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -2623,9 +2621,6 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -4843,7 +4838,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 3.1.5
+      minimatch: 3.1.5(patch_hash=1569eeafd2181ce206249d08003a6b577ec82e1f949cc16af59bfcea6d80a5d7)
     transitivePeerDependencies:
       - supports-color
 
@@ -4864,7 +4859,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.3.0
-      minimatch: 3.1.5
+      minimatch: 3.1.5(patch_hash=1569eeafd2181ce206249d08003a6b577ec82e1f949cc16af59bfcea6d80a5d7)
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -6410,8 +6405,6 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -6450,11 +6443,6 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
-
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
 
   brace-expansion@5.0.8:
     dependencies:
@@ -6569,8 +6557,6 @@ snapshots:
   commander@14.0.3: {}
 
   commander@4.1.1: {}
-
-  concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
 
@@ -6873,7 +6859,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.5
+      minimatch: 3.1.5(patch_hash=1569eeafd2181ce206249d08003a6b577ec82e1f949cc16af59bfcea6d80a5d7)
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -7432,9 +7418,9 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.8
 
-  minimatch@3.1.5:
+  minimatch@3.1.5(patch_hash=1569eeafd2181ce206249d08003a6b577ec82e1f949cc16af59bfcea6d80a5d7):
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
- replace vulnerable `brace-expansion` versions with patched 5.0.8
- patch minimatch 3.1.5 to accept brace-expansion v5 named exports
- include pnpm patches in API/admin Docker install stages

Fixes high-severity [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) / CVE-2026-14257.

## Verification
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=... pnpm db:generate`
- `pnpm audit` (1 high before, 0 after)
- `pnpm lint` (0 errors; 21 existing warnings)
- `pnpm test` (48 files, 240 tests)
- `DATABASE_URL=... pnpm build`
- `pnpm smoke:cli`
- `docker compose down && docker compose up -d --build`
- API health OK; admin and website HTTP 200