### PR TITLE
fix(api): authorize destructive repository reset

### DIFF
--- a/apps/api/src/__tests__/auth-middleware.test.ts
+++ b/apps/api/src/__tests__/auth-middleware.test.ts
@@ -24,6 +24,7 @@ describe("auth middleware", () => {
     store.validateApiKey.mockResolvedValue({
       id: "key-id",
       orgId: "org-id",
+      repoId: null,
       name: "test-key",
     });
     const app = await buildProtectedApp(store);

--- a/apps/api/src/__tests__/curate.test.ts
+++ b/apps/api/src/__tests__/curate.test.ts
@@ -1,0 +1,46 @@
+import Fastify from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import type { RemoteStore } from "unforgit-db";
+import { createAuthMiddleware } from "../middleware/auth.js";
+import { curateRoutes } from "../routes/curate.js";
+
+describe("curate routes", () => {
+  it("does not let a repository-scoped API key reset another repository", async () => {
+    const store = {
+      validateApiKey: vi.fn().mockResolvedValue({
+        id: "key-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        name: "test-key",
+      }),
+      resetAll: vi.fn().mockResolvedValue({ memories: 1 }),
+    } as unknown as RemoteStore;
+    const app = Fastify();
+    app.addHook("onRequest", createAuthMiddleware(store));
+    await curateRoutes(app, store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/memories/reset",
+      headers: { authorization: "Bearer valid-token" },
+      payload: { orgId: "org-a", repoId: "repo-b" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.resetAll).not.toHaveBeenCalled();
+
+    const ownRepoResponse = await app.inject({
+      method: "POST",
+      url: "/v1/memories/reset",
+      headers: { authorization: "Bearer valid-token" },
+      payload: { orgId: "org-a", repoId: "repo-a" },
+    });
+
+    expect(ownRepoResponse.statusCode).toBe(200);
+    expect(store.resetAll).toHaveBeenCalledOnce();
+    expect(store.resetAll).toHaveBeenCalledWith("org-a", "repo-a");
+
+    await app.close();
+  });
+});

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -6,6 +6,7 @@ declare module "fastify" {
     apiKey?: {
       id: string;
       orgId: string;
+      repoId: string | null;
       name: string;
     };
   }

--- a/apps/api/src/routes/curate.ts
+++ b/apps/api/src/routes/curate.ts
@@ -12,6 +12,11 @@ const lifecycleRunSchema = z.object({
   preserveOriginals: z.boolean().optional(),
 });
 
+const resetSchema = z.object({
+  orgId: z.string().min(1),
+  repoId: z.string().min(1),
+});
+
 export async function curateRoutes(
   app: FastifyInstance,
   store: RemoteStore,
@@ -57,12 +62,23 @@ export async function curateRoutes(
   );
 
   app.post("/v1/memories/reset", async (request, reply) => {
-    const body = request.body as { orgId?: string; repoId?: string } | undefined;
-    if (!body?.orgId || !body?.repoId) {
+    const parsed = resetSchema.safeParse(request.body);
+    if (!parsed.success) {
       return reply.status(400).send({ error: "orgId and repoId are required" });
     }
 
-    const result = await store.resetAll(body.orgId, body.repoId);
+    const { orgId, repoId } = parsed.data;
+    const apiKey = request.apiKey;
+    const orgMatches = apiKey?.orgId.toLowerCase() === orgId.toLowerCase();
+    const repoMatches =
+      apiKey?.repoId === null ||
+      apiKey?.repoId.toLowerCase() === repoId.toLowerCase();
+
+    if (!orgMatches || !repoMatches) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
+
+    const result = await store.resetAll(orgId, repoId);
     return reply.send(result);
   });
 

--- a/packages/db/src/remote.ts
+++ b/packages/db/src/remote.ts
@@ -917,7 +917,7 @@ export class RemoteStore {
     await this.prisma.$disconnect();
   }
 
-  async validateApiKey(key: string): Promise<{ id: string; orgId: string; name: string } | null> {
+  async validateApiKey(key: string): Promise<{ id: string; orgId: string; repoId: string | null; name: string } | null> {
     const apiKey = await this.prisma.apiKey.findUnique({
       where: { key },
     });
@@ -934,6 +934,7 @@ export class RemoteStore {
     return {
       id: apiKey.id,
       orgId: apiKey.orgId,
+      repoId: apiKey.repoId,
       name: apiKey.name,
     };
   }


### PR DESCRIPTION
## Summary
- bind `POST /v1/memories/reset` to the authenticated API key organization/repository scope
- retain organization-wide key behavior while denying cross-scope resets with 403
- validate the reset payload and cover denied plus same-scope behavior

## Verification
- `pnpm exec vitest run apps/api/src/__tests__/curate.test.ts apps/api/src/__tests__/auth-middleware.test.ts`
- `DATABASE_URL=postgresql://dummy:dummy@localhost:5432/dummy pnpm test` (49 files, 241 tests)
- `pnpm lint` (no errors; 21 existing warnings)
- `pnpm build`
- `pnpm smoke:cli`
- `pnpm audit` (no known vulnerabilities)
- `docker compose down && docker compose up -d --build`; `/health` OK