### PR TITLE
fix(api): authorize memory deletion

### DIFF
--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -1,15 +1,22 @@
 import Fastify from "fastify";
 import { describe, expect, it, vi } from "vitest";
 import type { RemoteStore } from "unforgit-db";
+import { createAuthMiddleware } from "../middleware/auth.js";
 import { syncRoutes } from "../routes/sync.js";
 
 function buildStore() {
   return {
     applyTombstone: vi.fn(),
+    getById: vi.fn(),
+    hardDelete: vi.fn(),
     upsertFromLocal: vi.fn(),
+    validateApiKey: vi.fn(),
   } as unknown as RemoteStore & {
     applyTombstone: ReturnType<typeof vi.fn>;
+    getById: ReturnType<typeof vi.fn>;
+    hardDelete: ReturnType<typeof vi.fn>;
     upsertFromLocal: ReturnType<typeof vi.fn>;
+    validateApiKey: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -46,6 +53,39 @@ describe("sync routes", () => {
 
     expect(response.statusCode).toBe(400);
     expect(store.applyTombstone).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("does not let a repository-scoped API key hard-delete another repository's memory", async () => {
+    const store = buildStore();
+    store.validateApiKey.mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    });
+    store.getById.mockResolvedValue({
+      id: "memory-id",
+      orgId: "org-a",
+      repoId: "repo-b",
+    });
+    store.hardDelete.mockResolvedValue(true);
+
+    const app = Fastify();
+    app.addHook("onRequest", createAuthMiddleware(store));
+    await app.register(syncRoutes, { store });
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/v1/memory/memory-id",
+      headers: { authorization: "Bearer valid-token" },
+      payload: { hardDelete: true },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.hardDelete).not.toHaveBeenCalled();
 
     await app.close();
   });

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -194,6 +194,22 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     async (request, reply) => {
       const { id } = request.params;
       const { deletedBy, hardDelete } = request.body ?? {};
+      const memory = await store.getById(id);
+
+      if (!memory) {
+        return reply.status(404).send({ error: "Memory not found" });
+      }
+
+      const apiKey = request.apiKey;
+      const orgMatches =
+        apiKey?.orgId.toLowerCase() === memory.orgId.toLowerCase();
+      const repoMatches =
+        apiKey?.repoId === null ||
+        apiKey?.repoId.toLowerCase() === memory.repoId.toLowerCase();
+
+      if (!orgMatches || !repoMatches) {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
 
       if (hardDelete) {
         const success = await store.hardDelete(id);


### PR DESCRIPTION
## Summary
- load the target memory before soft or hard deletion
- enforce the authenticated API key organization/repository scope
- reject cross-repository deletion attempts before calling the store

## Regression coverage
- repository-scoped keys receive `403` when attempting to hard-delete another repository

## Verification
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `pnpm lint` (21 existing warnings, 0 errors)
- `pnpm test` (49 files, 242 tests)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --json` (0 vulnerabilities)
- `docker compose down && docker compose up -d --build`; API `/health` returned `ok`