### PR TITLE
fix(api): authorize lifecycle maintenance

### DIFF
--- a/apps/api/src/__tests__/curate.test.ts
+++ b/apps/api/src/__tests__/curate.test.ts
@@ -43,4 +43,32 @@ describe("curate routes", () => {
 
     await app.close();
   });
+
+  it("does not let a repository-scoped API key run lifecycle maintenance on another repository", async () => {
+    const store = {
+      validateApiKey: vi.fn().mockResolvedValue({
+        id: "key-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        name: "test-key",
+      }),
+      list: vi.fn(),
+    } as unknown as RemoteStore;
+    const app = Fastify();
+    app.addHook("onRequest", createAuthMiddleware(store));
+    await curateRoutes(app, store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/lifecycle/run",
+      headers: { authorization: "Bearer valid-token" },
+      payload: { orgId: "org-a", repoId: "repo-b", dryRun: false },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.list).not.toHaveBeenCalled();
+
+    await app.close();
+  });
 });

--- a/apps/api/src/routes/curate.ts
+++ b/apps/api/src/routes/curate.ts
@@ -89,6 +89,15 @@ export async function curateRoutes(
     }
 
     const { orgId, repoId, ...options } = parsed.data;
+    const apiKey = request.apiKey;
+    const orgMatches = apiKey?.orgId.toLowerCase() === orgId.toLowerCase();
+    const repoMatches =
+      apiKey?.repoId === null ||
+      apiKey?.repoId.toLowerCase() === repoId.toLowerCase();
+
+    if (!orgMatches || !repoMatches) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
 
     try {
       const result = await runRemoteLifecycleMaintenance(


### PR DESCRIPTION
## Summary
- enforce API key organization and repository scope on `POST /v1/lifecycle/run`
- reject cross-repository lifecycle maintenance before accessing the target store
- add a regression test proving a repository-scoped key receives `403` and performs no reads

## Security impact
A repository-scoped API key could previously submit a different `repoId` and trigger destructive lifecycle maintenance outside its authorized repository.

## Verification
- focused regression test
- full test suite
- lint
- build
- CLI smoke test
- pnpm audit
