### PR TITLE
fix(api): authorize memory consolidation

### DIFF
--- a/apps/api/src/__tests__/consolidate.test.ts
+++ b/apps/api/src/__tests__/consolidate.test.ts
@@ -1,0 +1,35 @@
+import Fastify from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import type { RemoteStore } from "unforgit-db";
+import { createAuthMiddleware } from "../middleware/auth.js";
+import { consolidateRoutes } from "../routes/consolidate.js";
+
+describe("consolidate routes", () => {
+  it("does not let a repository-scoped API key consolidate another repository", async () => {
+    const store = {
+      validateApiKey: vi.fn().mockResolvedValue({
+        id: "key-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        name: "test-key",
+      }),
+      recall: vi.fn(),
+    } as unknown as RemoteStore;
+    const app = Fastify();
+    app.addHook("onRequest", createAuthMiddleware(store));
+    await consolidateRoutes(app, store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/consolidate",
+      headers: { authorization: "Bearer valid-token" },
+      payload: { orgId: "org-a", repoId: "repo-b" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.recall).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/consolidate.ts
+++ b/apps/api/src/routes/consolidate.ts
@@ -14,6 +14,15 @@ export async function consolidateRoutes(
 
     const { orgId, repoId, source, lastN } = parsed.data;
     const window = parsed.data.window;
+    const apiKey = request.apiKey;
+    const orgMatches = apiKey?.orgId.toLowerCase() === orgId.toLowerCase();
+    const repoMatches =
+      apiKey?.repoId === null ||
+      apiKey?.repoId.toLowerCase() === repoId.toLowerCase();
+
+    if (!orgMatches || !repoMatches) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
 
     const recentMemories = await store.recall({
       orgId,


### PR DESCRIPTION
## Summary
- validate the authenticated API key organization and repository scope before consolidation reads or mutations
- return 403 for cross-repository consolidation attempts
- add a regression test proving the remote store is not queried

## Security impact
Prevents repository-scoped API keys from reading and superseding memories in another repository through `POST /v1/consolidate`.

## Verification
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://… pnpm db:generate`
- `pnpm lint` (21 pre-existing warnings)
- `pnpm test` (51 files, 247 tests)
- `DATABASE_URL=postgresql://… pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --audit-level low` (0 vulnerabilities)
- `docker compose down && docker compose up -d --build`