### PR TITLE
fix(api): authorize auto-consolidation

### DIFF
--- a/apps/api/src/__tests__/auto-consolidate.test.ts
+++ b/apps/api/src/__tests__/auto-consolidate.test.ts
@@ -1,0 +1,90 @@
+import Fastify from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RemoteStore } from "unforgit-db";
+import { createAuthMiddleware } from "../middleware/auth.js";
+import { autoConsolidateRoutes } from "../routes/auto-consolidate.js";
+
+describe("auto-consolidate routes", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    ["/v1/auto-consolidate/preview", { orgId: "org-a", repoId: "repo-b" }],
+    ["/v1/auto-consolidate", { orgId: "org-a", repoId: "repo-b" }],
+    [
+      "/v1/auto-consolidate/execute",
+      { orgId: "org-a", repoId: "repo-b", sourceIds: ["one", "two"] },
+    ],
+  ])(
+    "does not let a repository-scoped API key access another repository through %s",
+    async (url, payload) => {
+      const store = {
+        validateApiKey: vi.fn().mockResolvedValue({
+          id: "key-id",
+          orgId: "org-a",
+          repoId: "repo-a",
+          name: "test-key",
+        }),
+        list: vi.fn(),
+        getById: vi.fn(),
+      } as unknown as RemoteStore;
+      const app = Fastify();
+      app.addHook("onRequest", createAuthMiddleware(store));
+      await autoConsolidateRoutes(app, store);
+
+      const response = await app.inject({
+        method: "POST",
+        url,
+        headers: { authorization: "Bearer valid-token" },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.json()).toEqual({ error: "Forbidden" });
+      expect(store.list).not.toHaveBeenCalled();
+      expect(store.getById).not.toHaveBeenCalled();
+
+      await app.close();
+    },
+  );
+
+  it("does not consolidate source memories from outside the requested repository", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-test-key");
+    const store = {
+      validateApiKey: vi.fn().mockResolvedValue({
+        id: "key-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        name: "test-key",
+      }),
+      getById: vi.fn().mockResolvedValue({
+        id: "foreign-memory",
+        orgId: "org-a",
+        repoId: "repo-b",
+        text: "private",
+        tags: [],
+      }),
+    } as unknown as RemoteStore;
+    const app = Fastify();
+    app.addHook("onRequest", createAuthMiddleware(store));
+    await autoConsolidateRoutes(app, store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/auto-consolidate/execute",
+      headers: { authorization: "Bearer valid-token" },
+      payload: {
+        orgId: "org-a",
+        repoId: "repo-a",
+        sourceIds: ["foreign-memory", "another-memory"],
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({ error: "Memory not found: foreign-memory" });
+    expect(store.getById).toHaveBeenCalledTimes(1);
+
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/auto-consolidate.ts
+++ b/apps/api/src/routes/auto-consolidate.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
 import type { RemoteStore } from "unforgit-db";
 import {
@@ -44,6 +44,19 @@ const executeGroupSchema = z.object({
   model: z.string().optional(),
 });
 
+function hasRepositoryAccess(
+  apiKey: FastifyRequest["apiKey"],
+  orgId: string,
+  repoId: string
+): boolean {
+  const orgMatches = apiKey?.orgId.toLowerCase() === orgId.toLowerCase();
+  const repoMatches =
+    apiKey?.repoId === null ||
+    apiKey?.repoId.toLowerCase() === repoId.toLowerCase();
+
+  return orgMatches && repoMatches;
+}
+
 export async function autoConsolidateRoutes(
   app: FastifyInstance,
   store: RemoteStore
@@ -55,6 +68,10 @@ export async function autoConsolidateRoutes(
     }
 
     const { orgId, repoId, ...options } = parsed.data;
+
+    if (!hasRepositoryAccess(request.apiKey, orgId, repoId)) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
 
     try {
       const result = await findConsolidationCandidatesRemote(
@@ -94,19 +111,23 @@ export async function autoConsolidateRoutes(
   });
 
   app.post("/v1/auto-consolidate", async (request, reply) => {
-    if (!isOpenAIConfigured()) {
-      return reply.status(503).send({
-        error: "OpenAI API key not configured on server",
-        hint: "Set OPENAI_API_KEY environment variable for LLM-powered consolidation",
-      });
-    }
-
     const parsed = executeSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.status(400).send({ error: parsed.error.issues });
     }
 
     const { orgId, repoId, model, preserveOriginals, ...options } = parsed.data;
+
+    if (!hasRepositoryAccess(request.apiKey, orgId, repoId)) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
+
+    if (!isOpenAIConfigured()) {
+      return reply.status(503).send({
+        error: "OpenAI API key not configured on server",
+        hint: "Set OPENAI_API_KEY environment variable for LLM-powered consolidation",
+      });
+    }
 
     try {
       const result = await autoConsolidateRemote(store, orgId, repoId, {
@@ -139,13 +160,6 @@ export async function autoConsolidateRoutes(
   });
 
   app.post("/v1/auto-consolidate/execute", async (request, reply) => {
-    if (!isOpenAIConfigured()) {
-      return reply.status(503).send({
-        error: "OpenAI API key not configured on server",
-        hint: "Set OPENAI_API_KEY environment variable for LLM-powered consolidation",
-      });
-    }
-
     const parsed = executeGroupSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.status(400).send({ error: parsed.error.issues });
@@ -153,10 +167,25 @@ export async function autoConsolidateRoutes(
 
     const { orgId, repoId, sourceIds, preserveOriginals, model } = parsed.data;
 
+    if (!hasRepositoryAccess(request.apiKey, orgId, repoId)) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
+
+    if (!isOpenAIConfigured()) {
+      return reply.status(503).send({
+        error: "OpenAI API key not configured on server",
+        hint: "Set OPENAI_API_KEY environment variable for LLM-powered consolidation",
+      });
+    }
+
     const memories = [];
     for (const id of sourceIds) {
       const memory = await store.getById(id);
-      if (!memory) {
+      if (
+        !memory ||
+        memory.orgId.toLowerCase() !== orgId.toLowerCase() ||
+        memory.repoId.toLowerCase() !== repoId.toLowerCase()
+      ) {
         return reply.status(404).send({ error: `Memory not found: ${id}` });
       }
       memories.push(memory);


### PR DESCRIPTION
## Summary
- enforce API-key organization/repository scope on all auto-consolidation endpoints
- reject source memories outside the requested repository during manual execution
- add regression coverage for cross-repository preview and mutation attempts

## Verification
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `pnpm lint` (21 existing warnings)
- `pnpm test` (52 files, 251 tests)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --audit-level=low` (0 vulnerabilities)
- `docker compose down && docker compose up -d --build`; API, website, and admin HTTP checks passed