### PR TITLE
fix(api): authorize memory reads

### DIFF
--- a/apps/api/src/__tests__/memory.test.ts
+++ b/apps/api/src/__tests__/memory.test.ts
@@ -1,20 +1,31 @@
 import Fastify from "fastify";
 import { describe, expect, it, vi } from "vitest";
 import type { RemoteStore } from "unforgit-db";
+import { createAuthMiddleware } from "../middleware/auth.js";
 import { memoryRoutes } from "../routes/memory.js";
 
 function buildStore() {
   return {
     list: vi.fn(),
     count: vi.fn(),
+    getById: vi.fn(),
+    validateApiKey: vi.fn().mockResolvedValue({
+      id: "key-id",
+      orgId: "org",
+      repoId: "repo",
+      name: "test-key",
+    }),
   } as unknown as RemoteStore & {
     list: ReturnType<typeof vi.fn>;
     count: ReturnType<typeof vi.fn>;
+    getById: ReturnType<typeof vi.fn>;
+    validateApiKey: ReturnType<typeof vi.fn>;
   };
 }
 
 async function buildMemoryApp(store: RemoteStore) {
   const app = Fastify();
+  app.addHook("onRequest", createAuthMiddleware(store));
   await memoryRoutes(app, store);
   return app;
 }
@@ -30,6 +41,7 @@ describe("memory routes", () => {
     const response = await app.inject({
       method: "GET",
       url: `/v1/memories?orgId=org&repoId=repo&${parameter}=${value}`,
+      headers: { authorization: "Bearer valid-token" },
     });
 
     expect(response.statusCode).toBe(400);
@@ -37,6 +49,58 @@ describe("memory routes", () => {
       error: "Bad Request",
       message,
     });
+    expect(store.list).not.toHaveBeenCalled();
+    expect(store.count).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("does not let a repository-scoped API key read another repository's memory", async () => {
+    const store = buildStore();
+    store.validateApiKey.mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    });
+    store.getById.mockResolvedValue({
+      id: "memory-id",
+      orgId: "org-a",
+      repoId: "repo-b",
+      text: "private memory",
+    });
+    const app = await buildMemoryApp(store);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/memory/memory-id",
+      headers: { authorization: "Bearer valid-token" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+
+    await app.close();
+  });
+
+  it("does not let a repository-scoped API key list another repository's memories", async () => {
+    const store = buildStore();
+    store.validateApiKey.mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    });
+    const app = await buildMemoryApp(store);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/memories?orgId=org-a&repoId=repo-b",
+      headers: { authorization: "Bearer valid-token" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
     expect(store.list).not.toHaveBeenCalled();
     expect(store.count).not.toHaveBeenCalled();
 

--- a/apps/api/src/routes/memory.ts
+++ b/apps/api/src/routes/memory.ts
@@ -28,6 +28,16 @@ export async function memoryRoutes(
       return reply.status(400).send({ error: "orgId and repoId are required" });
     }
 
+    const apiKey = request.apiKey;
+    const orgMatches = apiKey?.orgId.toLowerCase() === query.orgId.toLowerCase();
+    const repoMatches =
+      apiKey?.repoId === null ||
+      apiKey?.repoId.toLowerCase() === query.repoId.toLowerCase();
+
+    if (!orgMatches || !repoMatches) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
+
     const limit = parseIntegerParam(query.limit, 50, 1);
     if (limit === undefined) {
       return reply.status(400).send({
@@ -69,6 +79,18 @@ export async function memoryRoutes(
     if (!memory) {
       return reply.status(404).send({ error: "Memory not found" });
     }
+
+    const apiKey = request.apiKey;
+    const orgMatches =
+      apiKey?.orgId.toLowerCase() === memory.orgId.toLowerCase();
+    const repoMatches =
+      apiKey?.repoId === null ||
+      apiKey?.repoId.toLowerCase() === memory.repoId.toLowerCase();
+
+    if (!orgMatches || !repoMatches) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
+
     return reply.send({ memory });
   });
 


### PR DESCRIPTION
## Summary
- enforce organization/repository API-key scope when listing memories
- enforce the same scope when fetching a memory by ID
- add regression coverage for cross-repository list and direct reads

## Security impact
Repository-scoped API keys could previously read memories from another repository by supplying its repository identifiers or a known memory ID. Requests outside the authenticated key scope now return 403 before listing data, and direct reads validate the fetched memory scope.

## Verification
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `pnpm lint` (0 errors, 21 existing warnings)
- `pnpm test` (52 files, 253 tests)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --json` (0 vulnerabilities)
- `docker compose down && docker compose up -d --build`; API health and website/admin HTTP checks passed