### PR TITLE
fix(api): authorize sync operations

### DIFF
--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -7,14 +7,22 @@ import { syncRoutes } from "../routes/sync.js";
 function buildStore() {
   return {
     applyTombstone: vi.fn(),
+    getAllLinks: vi.fn(),
     getById: vi.fn(),
+    getUnsyncedTombstones: vi.fn(),
     hardDelete: vi.fn(),
+    list: vi.fn(),
+    restore: vi.fn(),
     upsertFromLocal: vi.fn(),
     validateApiKey: vi.fn(),
   } as unknown as RemoteStore & {
     applyTombstone: ReturnType<typeof vi.fn>;
+    getAllLinks: ReturnType<typeof vi.fn>;
     getById: ReturnType<typeof vi.fn>;
+    getUnsyncedTombstones: ReturnType<typeof vi.fn>;
     hardDelete: ReturnType<typeof vi.fn>;
+    list: ReturnType<typeof vi.fn>;
+    restore: ReturnType<typeof vi.fn>;
     upsertFromLocal: ReturnType<typeof vi.fn>;
     validateApiKey: ReturnType<typeof vi.fn>;
   };
@@ -86,6 +94,104 @@ describe("sync routes", () => {
     expect(response.statusCode).toBe(403);
     expect(response.json()).toEqual({ error: "Forbidden" });
     expect(store.hardDelete).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it.each([
+    ["/v1/sync/pull?orgId=org-a&repoId=repo-b", "list"],
+    ["/v1/sync/tombstones?orgId=org-a&repoId=repo-b", "getUnsyncedTombstones"],
+    ["/v1/sync/links?orgId=org-a&repoId=repo-b", "getAllLinks"],
+  ] as const)(
+    "does not let a repository-scoped API key read another repository via %s",
+    async (url, storeMethod) => {
+      const store = buildStore();
+      store.validateApiKey.mockResolvedValue({
+        id: "key-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        name: "test-key",
+      });
+      const app = Fastify();
+      app.addHook("onRequest", createAuthMiddleware(store));
+      await app.register(syncRoutes, { store });
+
+      const response = await app.inject({
+        method: "GET",
+        url,
+        headers: { authorization: "Bearer valid-token" },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.json()).toEqual({ error: "Forbidden" });
+      expect(store[storeMethod]).not.toHaveBeenCalled();
+
+      await app.close();
+    },
+  );
+
+  it.each([
+    ["/v1/sync/push", "upsertFromLocal", { orgId: "org-a", repoId: "repo-b" }],
+    [
+      "/v1/sync/tombstones",
+      "applyTombstone",
+      { orgId: "org-a", repoId: "repo-b" },
+    ],
+  ] as const)(
+    "does not let a repository-scoped API key write another repository via %s",
+    async (url, storeMethod, payload) => {
+      const store = buildStore();
+      store.validateApiKey.mockResolvedValue({
+        id: "key-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        name: "test-key",
+      });
+      const app = Fastify();
+      app.addHook("onRequest", createAuthMiddleware(store));
+      await app.register(syncRoutes, { store });
+
+      const response = await app.inject({
+        method: "POST",
+        url,
+        headers: { authorization: "Bearer valid-token" },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.json()).toEqual({ error: "Forbidden" });
+      expect(store[storeMethod]).not.toHaveBeenCalled();
+
+      await app.close();
+    },
+  );
+
+  it("does not let a repository-scoped API key restore another repository's memory", async () => {
+    const store = buildStore();
+    store.validateApiKey.mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    });
+    store.getById.mockResolvedValue({
+      id: "memory-id",
+      orgId: "org-a",
+      repoId: "repo-b",
+    });
+    const app = Fastify();
+    app.addHook("onRequest", createAuthMiddleware(store));
+    await app.register(syncRoutes, { store });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/memory/memory-id/restore",
+      headers: { authorization: "Bearer valid-token" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.restore).not.toHaveBeenCalled();
 
     await app.close();
   });

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -1,4 +1,4 @@
-import type { FastifyPluginAsync } from "fastify";
+import type { FastifyPluginAsync, FastifyRequest } from "fastify";
 import { RemoteStore } from "unforgit-db";
 import type { Memory, Tombstone } from "unforgit-shared";
 
@@ -38,6 +38,19 @@ interface PushBody {
   updatedAt: string;
 }
 
+function hasApiKeyScope(
+  request: FastifyRequest,
+  orgId: string,
+  repoId: string,
+): boolean {
+  const apiKey = request.apiKey;
+  return Boolean(
+    apiKey?.orgId.toLowerCase() === orgId.toLowerCase() &&
+    (apiKey.repoId === null ||
+      apiKey.repoId.toLowerCase() === repoId.toLowerCase()),
+  );
+}
+
 export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
   app,
   { store },
@@ -49,6 +62,10 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
 
       if (!orgId || !repoId) {
         return reply.status(400).send({ error: "orgId and repoId are required" });
+      }
+
+      if (!hasApiKeyScope(request, orgId, repoId)) {
+        return reply.status(403).send({ error: "Forbidden" });
       }
 
       let memories: Memory[];
@@ -94,6 +111,10 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
 
       if (!body) {
         return reply.status(400).send({ error: "Request body is required" });
+      }
+
+      if (!hasApiKeyScope(request, body.orgId, body.repoId)) {
+        return reply.status(403).send({ error: "Forbidden" });
       }
 
       const memory: Memory = {
@@ -145,6 +166,10 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         return reply.status(400).send({ error: "orgId and repoId are required" });
       }
 
+      if (!hasApiKeyScope(request, orgId, repoId)) {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
+
       const tombstones = since
         ? await store.getTombstones(orgId, repoId, new Date(since))
         : await store.getUnsyncedTombstones(orgId, repoId);
@@ -168,6 +193,10 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
 
       if (!body) {
         return reply.status(400).send({ error: "Request body is required" });
+      }
+
+      if (!hasApiKeyScope(request, body.orgId, body.repoId)) {
+        return reply.status(403).send({ error: "Forbidden" });
       }
 
       const tombstone: Tombstone = {
@@ -200,14 +229,7 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         return reply.status(404).send({ error: "Memory not found" });
       }
 
-      const apiKey = request.apiKey;
-      const orgMatches =
-        apiKey?.orgId.toLowerCase() === memory.orgId.toLowerCase();
-      const repoMatches =
-        apiKey?.repoId === null ||
-        apiKey?.repoId.toLowerCase() === memory.repoId.toLowerCase();
-
-      if (!orgMatches || !repoMatches) {
+      if (!hasApiKeyScope(request, memory.orgId, memory.repoId)) {
         return reply.status(403).send({ error: "Forbidden" });
       }
 
@@ -233,6 +255,15 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     async (request, reply) => {
       const { id } = request.params;
 
+      const memory = await store.getById(id);
+      if (!memory) {
+        return reply.status(404).send({ error: "Memory not found or not deleted" });
+      }
+
+      if (!hasApiKeyScope(request, memory.orgId, memory.repoId)) {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
+
       const success = await store.restore(id);
       if (success) {
         return reply.send({ success: true });
@@ -249,6 +280,10 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
 
       if (!orgId || !repoId) {
         return reply.status(400).send({ error: "orgId and repoId are required" });
+      }
+
+      if (!hasApiKeyScope(request, orgId, repoId)) {
+        return reply.status(403).send({ error: "Forbidden" });
       }
 
       const links = await store.getAllLinks(orgId, repoId);


### PR DESCRIPTION
## Summary
- enforce authenticated API-key organization/repository scope on sync pull, push, tombstone read/write, restore, and link export routes
- reuse the same scope check for memory deletion
- add cross-repository regression coverage for every affected operation

## Security impact
Repository-scoped API keys could previously supply another repository ID to sync routes and read or mutate that repository. Restore also accepted any known memory ID without checking ownership.

## Verification
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `pnpm lint` (0 errors, 21 existing warnings)
- `pnpm test` (52 files, 259 tests)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --json` (0 vulnerabilities)
- `docker compose down && docker compose up -d --build`
- API container `/health` returned 200