### PR TITLE
fix(api): authorize memory recall

### DIFF
--- a/apps/api/src/__tests__/recall.test.ts
+++ b/apps/api/src/__tests__/recall.test.ts
@@ -1,0 +1,45 @@
+import Fastify from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import type { RemoteStore } from "unforgit-db";
+import { createAuthMiddleware } from "../middleware/auth.js";
+import { recallRoutes } from "../routes/recall.js";
+
+describe("recall routes", () => {
+  it("does not let a repository-scoped API key recall another repository", async () => {
+    const store = {
+      validateApiKey: vi.fn().mockResolvedValue({
+        id: "key-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        name: "test-key",
+      }),
+      recall: vi.fn(),
+      recallWithEmbeddings: vi.fn(),
+      recordUsageBatch: vi.fn(),
+    } as unknown as RemoteStore;
+    const scheduleLifecycle = vi.fn();
+    const app = Fastify();
+    app.addHook("onRequest", createAuthMiddleware(store));
+    await recallRoutes(app, store, scheduleLifecycle);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/recall",
+      headers: { authorization: "Bearer valid-token" },
+      payload: {
+        orgId: "org-a",
+        repoId: "repo-b",
+        query: "private memory",
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.recall).not.toHaveBeenCalled();
+    expect(store.recallWithEmbeddings).not.toHaveBeenCalled();
+    expect(store.recordUsageBatch).not.toHaveBeenCalled();
+    expect(scheduleLifecycle).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/recall.ts
+++ b/apps/api/src/routes/recall.ts
@@ -16,6 +16,16 @@ export async function recallRoutes(
     }
 
     const query = parsed.data;
+    const apiKey = request.apiKey;
+    const orgMatches = apiKey?.orgId.toLowerCase() === query.orgId.toLowerCase();
+    const repoMatches =
+      apiKey?.repoId === null ||
+      apiKey?.repoId.toLowerCase() === query.repoId.toLowerCase();
+
+    if (!orgMatches || !repoMatches) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
+
     let queryEmbedding: number[] | undefined;
 
     if (isOpenAIConfigured() && query.query) {


### PR DESCRIPTION
## Summary
- enforce API-key organization/repository scope on `POST /v1/recall`
- reject cross-repository recall before embeddings, reads, usage tracking, or lifecycle scheduling
- add regression coverage for repository-scoped keys

## Verification
- `pnpm exec vitest run apps/api/src/__tests__/recall.test.ts`
- `pnpm test` (53 files, 260 tests)
- `pnpm lint` (0 errors; 21 existing warnings)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`
- `docker compose down && docker compose up -d --build`
- API `/health` and website `/` return HTTP 200

## Release
No release requested; batch into the next approved release.