### PR TITLE
fix(deps): patch nanoid zero-size denial of service

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
       "body-parser@>=2.0.0 <2.3.0": "2.3.0",
       "@hono/node-server@<2.0.10": "2.0.10",
       "esbuild@>=0.17.0 <0.28.1": "0.28.1",
-      "@babel/core@<=7.29.0": "7.29.7"
+      "@babel/core@<=7.29.0": "7.29.7",
+      "nanoid@<3.3.18": "3.3.18"
     },
     "patchedDependencies": {
       "minimatch@3.1.5": "patches/minimatch@3.1.5.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ overrides:
   '@hono/node-server@<2.0.10': 2.0.10
   esbuild@>=0.17.0 <0.28.1: 0.28.1
   '@babel/core@<=7.29.0': 7.29.7
+  nanoid@<3.3.18: 3.3.18
 
 patchedDependencies:
   minimatch@3.1.5:
@@ -3565,8 +3566,8 @@ packages:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7468,7 +7469,7 @@ snapshots:
     dependencies:
       lru.min: 1.1.4
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -7686,7 +7687,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary
- override vulnerable transitive `nanoid` versions below 3.3.18
- refresh the pnpm lockfile so PostCSS resolves `nanoid@3.3.18`
- patch GHSA-2v37-7h3g-55p8 / CVE-2026-67213 (infinite-loop denial of service)

## Verification
- `pnpm audit --json`: 1 high before, 0 after
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `pnpm lint` (0 errors, 21 existing warnings)
- `pnpm test` (53 files, 260 tests)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`
- `docker compose down && docker compose up -d --build`
- API `/health`, website, and admin HTTP checks passed