### PR TITLE
fix(api): authorize memory creation

### DIFF
--- a/apps/api/src/__tests__/memory.test.ts
+++ b/apps/api/src/__tests__/memory.test.ts
@@ -9,6 +9,7 @@ function buildStore() {
     list: vi.fn(),
     count: vi.fn(),
     getById: vi.fn(),
+    store: vi.fn(),
     validateApiKey: vi.fn().mockResolvedValue({
       id: "key-id",
       orgId: "org",
@@ -19,6 +20,7 @@ function buildStore() {
     list: ReturnType<typeof vi.fn>;
     count: ReturnType<typeof vi.fn>;
     getById: ReturnType<typeof vi.fn>;
+    store: ReturnType<typeof vi.fn>;
     validateApiKey: ReturnType<typeof vi.fn>;
   };
 }
@@ -103,6 +105,35 @@ describe("memory routes", () => {
     expect(response.json()).toEqual({ error: "Forbidden" });
     expect(store.list).not.toHaveBeenCalled();
     expect(store.count).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("does not let a repository-scoped API key create a memory in another repository", async () => {
+    const store = buildStore();
+    store.validateApiKey.mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    });
+    const app = await buildMemoryApp(store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/memory",
+      headers: { authorization: "Bearer valid-token" },
+      payload: {
+        orgId: "org-a",
+        repoId: "repo-b",
+        text: "unauthorized memory",
+        memoryType: "semantic",
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.store).not.toHaveBeenCalled();
 
     await app.close();
   });

--- a/apps/api/src/routes/memory.ts
+++ b/apps/api/src/routes/memory.ts
@@ -100,6 +100,17 @@ export async function memoryRoutes(
       return reply.status(400).send({ error: parsed.error.issues });
     }
 
+    const apiKey = request.apiKey;
+    const orgMatches =
+      apiKey?.orgId.toLowerCase() === parsed.data.orgId.toLowerCase();
+    const repoMatches =
+      apiKey?.repoId === null ||
+      apiKey?.repoId.toLowerCase() === parsed.data.repoId.toLowerCase();
+
+    if (!orgMatches || !repoMatches) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
+
     const memory = await store.store(applyLifecycleDefaults(parsed.data));
     scheduleLifecycle?.(parsed.data.orgId, parsed.data.repoId);
 


### PR DESCRIPTION
## Summary
- reject memory creation outside the authenticated API key organization/repository scope
- compare scope identifiers case-insensitively, preserving organization-scoped key behavior
- add regression coverage proving unauthorized writes never reach the store

## Security impact
A repository-scoped API key could previously submit another `orgId`/`repoId` to `POST /v1/memory`, creating data and triggering lifecycle work outside its authorized repository.

## Verification
- `pnpm exec vitest run apps/api/src/__tests__/memory.test.ts`
- `pnpm lint` (passes with 21 pre-existing warnings)
- `pnpm test` (53 files, 261 tests)
- `pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --audit-level=high`
- `docker compose down && docker compose up -d --build`