### PR TITLE
fix(api): authorize link operations

### DIFF
--- a/apps/api/src/__tests__/links.test.ts
+++ b/apps/api/src/__tests__/links.test.ts
@@ -1,20 +1,35 @@
 import Fastify from "fastify";
 import { describe, expect, it, vi } from "vitest";
 import type { RemoteStore } from "unforgit-db";
+import { createAuthMiddleware } from "../middleware/auth.js";
 import { linkRoutes } from "../routes/links.js";
 
 function buildStore() {
   return {
+    getAllLinks: vi.fn(),
+    getById: vi.fn(),
+    getLinks: vi.fn(),
     link: vi.fn(),
     unlink: vi.fn(),
+    validateApiKey: vi.fn().mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    }),
   } as unknown as RemoteStore & {
+    getAllLinks: ReturnType<typeof vi.fn>;
+    getById: ReturnType<typeof vi.fn>;
+    getLinks: ReturnType<typeof vi.fn>;
     link: ReturnType<typeof vi.fn>;
     unlink: ReturnType<typeof vi.fn>;
+    validateApiKey: ReturnType<typeof vi.fn>;
   };
 }
 
 async function buildLinksApp(store: RemoteStore) {
   const app = Fastify();
+  app.addHook("onRequest", createAuthMiddleware(store));
   await linkRoutes(app, store);
   return app;
 }
@@ -29,9 +44,76 @@ describe("link routes", () => {
       const response = await app.inject({
         method,
         url: "/v1/memory/source-id/link",
+        headers: { authorization: "Bearer valid-token" },
       });
 
       expect(response.statusCode).toBe(400);
+      expect(store.link).not.toHaveBeenCalled();
+      expect(store.unlink).not.toHaveBeenCalled();
+
+      await app.close();
+    },
+  );
+
+  it("does not let a repository-scoped API key list another repository's links", async () => {
+    const store = buildStore();
+    const app = await buildLinksApp(store);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/links?orgId=org-a&repoId=repo-b",
+      headers: { authorization: "Bearer valid-token" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.getAllLinks).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("does not let a repository-scoped API key read another repository's memory links", async () => {
+    const store = buildStore();
+    store.getById.mockResolvedValue({
+      id: "memory-id",
+      orgId: "org-a",
+      repoId: "repo-b",
+    });
+    const app = await buildLinksApp(store);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/memory/memory-id/links",
+      headers: { authorization: "Bearer valid-token" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.getLinks).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it.each(["POST", "DELETE"] as const)(
+    "does not let a repository-scoped API key use %s to mutate another repository's links",
+    async (method) => {
+      const store = buildStore();
+      store.getById.mockImplementation(async (id: string) => ({
+        id,
+        orgId: "org-a",
+        repoId: id === "source-id" ? "repo-a" : "repo-b",
+      }));
+      const app = await buildLinksApp(store);
+
+      const response = await app.inject({
+        method,
+        url: "/v1/memory/source-id/link",
+        headers: { authorization: "Bearer valid-token" },
+        payload: { targetId: "target-id", linkType: "related_to" },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.json()).toEqual({ error: "Forbidden" });
       expect(store.link).not.toHaveBeenCalled();
       expect(store.unlink).not.toHaveBeenCalled();
 

--- a/apps/api/src/routes/links.ts
+++ b/apps/api/src/routes/links.ts
@@ -1,7 +1,16 @@
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest } from "fastify";
 import type { RemoteStore } from "unforgit-db";
 import { createLinkSchema, linkTypeSchema } from "unforgit-shared";
-import type { LinkType } from "unforgit-shared";
+import type { LinkType, Memory } from "unforgit-shared";
+
+function hasApiKeyScope(request: FastifyRequest, memory: Memory): boolean {
+  const apiKey = request.apiKey;
+  return Boolean(
+    apiKey?.orgId.toLowerCase() === memory.orgId.toLowerCase() &&
+    (apiKey.repoId === null ||
+      apiKey.repoId.toLowerCase() === memory.repoId.toLowerCase()),
+  );
+}
 
 export async function linkRoutes(
   app: FastifyInstance,
@@ -14,6 +23,16 @@ export async function linkRoutes(
 
       if (!orgId || !repoId) {
         return reply.status(400).send({ error: "orgId and repoId are required" });
+      }
+
+      const apiKey = request.apiKey;
+      const orgMatches = apiKey?.orgId.toLowerCase() === orgId.toLowerCase();
+      const repoMatches =
+        apiKey?.repoId === null ||
+        apiKey?.repoId.toLowerCase() === repoId.toLowerCase();
+
+      if (!orgMatches || !repoMatches) {
+        return reply.status(403).send({ error: "Forbidden" });
       }
 
       const links = await store.getAllLinks(orgId, repoId);
@@ -36,6 +55,17 @@ export async function linkRoutes(
 
       if (!parsed.success) {
         return reply.status(400).send({ error: parsed.error.issues });
+      }
+
+      const [source, target] = await Promise.all([
+        store.getById(parsed.data.sourceId),
+        store.getById(parsed.data.targetId),
+      ]);
+      if (!source || !target) {
+        return reply.status(404).send({ error: "Memory not found" });
+      }
+      if (!hasApiKeyScope(request, source) || !hasApiKeyScope(request, target)) {
+        return reply.status(403).send({ error: "Forbidden" });
       }
 
       try {
@@ -71,6 +101,17 @@ export async function linkRoutes(
         return reply.status(400).send({ error: typeCheck.error.issues });
       }
 
+      const [source, target] = await Promise.all([
+        store.getById(id),
+        store.getById(targetId),
+      ]);
+      if (!source || !target) {
+        return reply.status(404).send({ error: "Memory not found" });
+      }
+      if (!hasApiKeyScope(request, source) || !hasApiKeyScope(request, target)) {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
+
       const ok = await store.unlink(id, targetId, linkType);
       if (!ok) return reply.status(404).send({ error: "Link not found" });
       return reply.send({ ok: true });
@@ -88,6 +129,14 @@ export async function linkRoutes(
         if (!typeCheck.success) {
           return reply.status(400).send({ error: typeCheck.error.issues });
         }
+      }
+
+      const memory = await store.getById(id);
+      if (!memory) {
+        return reply.status(404).send({ error: "Memory not found" });
+      }
+      if (!hasApiKeyScope(request, memory)) {
+        return reply.status(403).send({ error: "Forbidden" });
       }
 
       const links = await store.getLinks({


### PR DESCRIPTION
## Summary
- enforce API-key organization/repository scope when listing links
- verify both source and target memory scope before creating or deleting links
- reject reads for memory IDs outside the authenticated key scope
- add cross-repository regression coverage

## Verification
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `pnpm lint` (21 existing warnings, 0 errors)
- `pnpm test` (53 files, 263 tests; then targeted 6 tests after preserving existing body-validation coverage)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --json` (0 vulnerabilities)
- `docker compose down && docker compose up -d --build`; API/admin/website HTTP checks passed