### PR TITLE
fix(api): authorize API key management

### DIFF
--- a/apps/api/src/__tests__/api-keys.test.ts
+++ b/apps/api/src/__tests__/api-keys.test.ts
@@ -7,9 +7,13 @@ import { apiKeyRoutes } from "../routes/api-keys.js";
 function buildStore() {
   return {
     createApiKey: vi.fn(),
+    listApiKeys: vi.fn().mockResolvedValue([]),
+    revokeApiKey: vi.fn(),
     validateApiKey: vi.fn(),
   } as unknown as RemoteStore & {
     createApiKey: ReturnType<typeof vi.fn>;
+    listApiKeys: ReturnType<typeof vi.fn>;
+    revokeApiKey: ReturnType<typeof vi.fn>;
     validateApiKey: ReturnType<typeof vi.fn>;
   };
 }
@@ -93,6 +97,59 @@ describe("API key routes", () => {
     expect(response.statusCode).toBe(403);
     expect(response.json()).toEqual({ error: "Forbidden" });
     expect(store.createApiKey).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("does not let an organization key list another organization's keys", async () => {
+    const store = buildStore();
+    store.validateApiKey.mockResolvedValue({
+      id: "org-key-id",
+      orgId: "org-a",
+      repoId: null,
+      name: "organization-key",
+    });
+    const app = Fastify();
+    app.addHook("onRequest", createAuthMiddleware(store));
+    await apiKeyRoutes(app, { store });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/api-keys?orgId=org-b",
+      headers: { authorization: "Bearer valid-token" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.listApiKeys).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("does not let an organization key revoke another organization's key", async () => {
+    const store = buildStore();
+    store.validateApiKey.mockResolvedValue({
+      id: "org-key-id",
+      orgId: "org-a",
+      repoId: null,
+      name: "organization-key",
+    });
+    store.listApiKeys.mockResolvedValue([
+      { id: "org-a-key-id", orgId: "org-a" },
+    ]);
+    const app = Fastify();
+    app.addHook("onRequest", createAuthMiddleware(store));
+    await apiKeyRoutes(app, { store });
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/v1/api-keys/org-b-key-id",
+      headers: { authorization: "Bearer valid-token" },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(store.listApiKeys).toHaveBeenCalledWith("org-a");
+    expect(store.revokeApiKey).not.toHaveBeenCalled();
 
     await app.close();
   });

--- a/apps/api/src/routes/api-keys.ts
+++ b/apps/api/src/routes/api-keys.ts
@@ -14,6 +14,16 @@ interface ListApiKeysQuery {
   orgId?: string;
 }
 
+function canManageOrgKeys(
+  apiKey: { orgId: string; repoId: string | null } | undefined,
+  orgId: string,
+): boolean {
+  return Boolean(
+    apiKey?.repoId === null &&
+      apiKey.orgId.toLowerCase() === orgId.toLowerCase(),
+  );
+}
+
 export const apiKeyRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
   app,
   { store },
@@ -30,12 +40,7 @@ export const apiKeyRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         });
       }
 
-      const callerKey = request.apiKey;
-      const canManageOrgKeys =
-        callerKey?.repoId === null &&
-        callerKey.orgId.toLowerCase() === orgId.toLowerCase();
-
-      if (!canManageOrgKeys) {
+      if (!canManageOrgKeys(request.apiKey, orgId)) {
         return reply.status(403).send({ error: "Forbidden" });
       }
 
@@ -56,7 +61,18 @@ export const apiKeyRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     async (request, reply) => {
       const { orgId } = request.query;
 
-      const keys = await store.listApiKeys(orgId);
+      const callerKey = request.apiKey;
+      const callerOrgId = callerKey?.orgId;
+      const requestedOrgId = orgId ?? callerOrgId;
+      if (
+        !callerOrgId ||
+        !requestedOrgId ||
+        !canManageOrgKeys(callerKey, requestedOrgId)
+      ) {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
+
+      const keys = await store.listApiKeys(callerOrgId);
 
       return reply.send({
         keys: keys.map((k) => ({
@@ -75,6 +91,19 @@ export const apiKeyRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     "/v1/api-keys/:id",
     async (request, reply) => {
       const { id } = request.params;
+
+      const callerKey = request.apiKey;
+      if (!callerKey || !canManageOrgKeys(callerKey, callerKey.orgId)) {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
+
+      const organizationKeys = await store.listApiKeys(callerKey.orgId);
+      if (!organizationKeys.some((key) => key.id === id)) {
+        return reply.status(404).send({
+          error: "Not Found",
+          message: "API key not found",
+        });
+      }
 
       const success = await store.revokeApiKey(id);
 


### PR DESCRIPTION
## Summary
- restrict API-key listing to organization-scoped keys for their own organization
- prevent organization keys from revoking keys owned by another organization
- add cross-organization authorization regression coverage

## Verification
- `pnpm vitest run apps/api/src/__tests__/api-keys.test.ts` (5 tests)
- `pnpm test` (53 files, 267 tests)
- `pnpm lint` (passes with 21 existing warnings)
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/unforgit pnpm db:generate`
- `pnpm build`
- `pnpm smoke:cli`
- `docker compose down && docker compose up -d --build`; `/health` OK

## Note
- `pnpm audit --audit-level high` reports the existing `deepmerge-ts` GHSA-ggr8-5vv4-36mx through Prisma tooling; not changed here to keep this security patch focused.