### PR TITLE
fix(deps): patch deepmerge cycle denial of service

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
       "@hono/node-server@<2.0.10": "2.0.10",
       "esbuild@>=0.17.0 <0.28.1": "0.28.1",
       "@babel/core@<=7.29.0": "7.29.7",
-      "nanoid@<3.3.18": "3.3.18"
+      "nanoid@<3.3.18": "3.3.18",
+      "deepmerge-ts@<8.0.0": "8.0.1"
     },
     "patchedDependencies": {
       "minimatch@3.1.5": "patches/minimatch@3.1.5.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ overrides:
   esbuild@>=0.17.0 <0.28.1: 0.28.1
   '@babel/core@<=7.29.0': 7.29.7
   nanoid@<3.3.18: 3.3.18
+  deepmerge-ts@<8.0.0: 8.0.1
 
 patchedDependencies:
   minimatch@3.1.5:
@@ -2779,8 +2780,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   defu@6.1.7:
@@ -5193,7 +5194,7 @@ snapshots:
   '@prisma/config@7.8.0':
     dependencies:
       c12: 3.3.4
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       effect: 3.20.0
       empathic: 2.0.0
     transitivePeerDependencies:
@@ -6690,7 +6691,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   defu@6.1.7: {}
 


### PR DESCRIPTION
## Summary
- override vulnerable `deepmerge-ts` versions to 8.0.1
- refresh the pnpm lockfile so Prisma resolves the patched release
- address GHSA-ggr8-5vv4-36mx / CVE-2026-40345

## Verification
- `pnpm audit` before: 1 high vulnerability
- `pnpm audit` after: 0 vulnerabilities
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `pnpm lint` (21 existing warnings, 0 errors)
- `pnpm test` (53 files, 267 tests)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`

Docker images built successfully; starting the isolated worktree stack was blocked because the maintained stack already owns port 3030.