### PR TITLE
fix(api): authorize memory curation

### DIFF
--- a/apps/api/src/__tests__/curate.test.ts
+++ b/apps/api/src/__tests__/curate.test.ts
@@ -4,7 +4,86 @@ import type { RemoteStore } from "unforgit-db";
 import { createAuthMiddleware } from "../middleware/auth.js";
 import { curateRoutes } from "../routes/curate.js";
 
+function buildStore() {
+  return {
+    validateApiKey: vi.fn().mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    }),
+    getById: vi.fn(),
+    deprecate: vi.fn(),
+    supersede: vi.fn(),
+    pin: vi.fn(),
+  } as unknown as RemoteStore & {
+    getById: ReturnType<typeof vi.fn>;
+    deprecate: ReturnType<typeof vi.fn>;
+    supersede: ReturnType<typeof vi.fn>;
+    pin: ReturnType<typeof vi.fn>;
+  };
+}
+
+async function buildCurateApp(store: RemoteStore) {
+  const app = Fastify();
+  app.addHook("onRequest", createAuthMiddleware(store));
+  await curateRoutes(app, store);
+  return app;
+}
+
 describe("curate routes", () => {
+  it.each([
+    ["deprecate", "/v1/memory/memory-id/deprecate", "deprecate"],
+    ["pin", "/v1/memory/memory-id/pin", "pin"],
+  ] as const)(
+    "does not let a repository-scoped API key %s another repository's memory",
+    async (_operation, url, storeMethod) => {
+      const store = buildStore();
+      store.getById.mockResolvedValue({
+        id: "memory-id",
+        orgId: "org-a",
+        repoId: "repo-b",
+      });
+      const app = await buildCurateApp(store);
+
+      const response = await app.inject({
+        method: "POST",
+        url,
+        headers: { authorization: "Bearer valid-token" },
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.json()).toEqual({ error: "Forbidden" });
+      expect(store[storeMethod]).not.toHaveBeenCalled();
+
+      await app.close();
+    },
+  );
+
+  it("does not let a repository-scoped API key supersede memories outside its repository", async () => {
+    const store = buildStore();
+    store.getById.mockImplementation(async (id: string) => ({
+      id,
+      orgId: "org-a",
+      repoId: id === "old-id" ? "repo-a" : "repo-b",
+    }));
+    const app = await buildCurateApp(store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/memory/old-id/supersede",
+      headers: { authorization: "Bearer valid-token" },
+      payload: { newId: "new-id" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.supersede).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
   it("does not let a repository-scoped API key reset another repository", async () => {
     const store = {
       validateApiKey: vi.fn().mockResolvedValue({

--- a/apps/api/src/routes/curate.ts
+++ b/apps/api/src/routes/curate.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { runRemoteLifecycleMaintenance } from "unforgit-core";
 import { deprecateSchema, supersedeSchema } from "unforgit-shared";
@@ -17,6 +17,19 @@ const resetSchema = z.object({
   repoId: z.string().min(1),
 });
 
+function hasMemoryAccess(
+  apiKey: FastifyRequest["apiKey"],
+  memory: { orgId: string; repoId: string },
+): boolean {
+  const orgMatches =
+    apiKey?.orgId.toLowerCase() === memory.orgId.toLowerCase();
+  const repoMatches =
+    apiKey?.repoId === null ||
+    apiKey?.repoId.toLowerCase() === memory.repoId.toLowerCase();
+
+  return orgMatches && repoMatches;
+}
+
 export async function curateRoutes(
   app: FastifyInstance,
   store: RemoteStore,
@@ -28,6 +41,12 @@ export async function curateRoutes(
       const parsed = deprecateSchema.safeParse(request.body ?? {});
       if (!parsed.success) {
         return reply.status(400).send({ error: parsed.error.issues });
+      }
+
+      const memory = await store.getById(id);
+      if (!memory) return reply.status(404).send({ error: "Memory not found" });
+      if (!hasMemoryAccess(request.apiKey, memory)) {
+        return reply.status(403).send({ error: "Forbidden" });
       }
 
       const ok = await store.deprecate(id, parsed.data.reason);
@@ -45,6 +64,20 @@ export async function curateRoutes(
         return reply.status(400).send({ error: parsed.error.issues });
       }
 
+      const [oldMemory, newMemory] = await Promise.all([
+        store.getById(id),
+        store.getById(parsed.data.newId),
+      ]);
+      if (!oldMemory || !newMemory) {
+        return reply.status(404).send({ error: "Memory not found" });
+      }
+      if (
+        !hasMemoryAccess(request.apiKey, oldMemory) ||
+        !hasMemoryAccess(request.apiKey, newMemory)
+      ) {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
+
       const ok = await store.supersede(id, parsed.data.newId);
       if (!ok) return reply.status(404).send({ error: "Memory not found" });
       return reply.send({ ok: true });
@@ -55,6 +88,12 @@ export async function curateRoutes(
     "/v1/memory/:id/pin",
     async (request, reply) => {
       const { id } = request.params;
+      const memory = await store.getById(id);
+      if (!memory) return reply.status(404).send({ error: "Memory not found" });
+      if (!hasMemoryAccess(request.apiKey, memory)) {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
+
       const ok = await store.pin(id);
       if (!ok) return reply.status(404).send({ error: "Memory not found" });
       return reply.send({ ok: true });


### PR DESCRIPTION
## Summary
- enforce API-key organization/repository scope before deprecating or pinning a memory
- require both source and replacement memories to be in scope before superseding
- add regression coverage for cross-repository curation attempts

## Verification
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `pnpm lint` (21 existing warnings, 0 errors)
- `pnpm test` (53 files, 270 tests)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --json` (0 vulnerabilities)
- `docker compose down && docker compose up -d --build`; API, admin, and website HTTP checks passed