### PR TITLE
fix(api): authorize repository insight routes

### DIFF
--- a/apps/api/src/__tests__/repository-insights-authorization.test.ts
+++ b/apps/api/src/__tests__/repository-insights-authorization.test.ts
@@ -1,0 +1,112 @@
+import Fastify from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import type { RemoteStore } from "unforgit-db";
+import { createAuthMiddleware } from "../middleware/auth.js";
+import { embeddingRoutes } from "../routes/embeddings.js";
+import { healthRoutes } from "../routes/health.js";
+import { suggestionsRoutes } from "../routes/suggestions.js";
+
+function buildStore() {
+  return {
+    validateApiKey: vi.fn().mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    }),
+    getById: vi.fn(),
+    getEmbeddingStats: vi.fn(),
+    getMemoriesWithoutEmbeddings: vi.fn(),
+    getUsageStats: vi.fn(),
+    stats: vi.fn(),
+    list: vi.fn(),
+  } as unknown as RemoteStore & {
+    getById: ReturnType<typeof vi.fn>;
+    getEmbeddingStats: ReturnType<typeof vi.fn>;
+    getMemoriesWithoutEmbeddings: ReturnType<typeof vi.fn>;
+    getUsageStats: ReturnType<typeof vi.fn>;
+    stats: ReturnType<typeof vi.fn>;
+    list: ReturnType<typeof vi.fn>;
+  };
+}
+
+async function buildApp(store: RemoteStore) {
+  const app = Fastify();
+  app.addHook("onRequest", createAuthMiddleware(store));
+  await embeddingRoutes(app, store);
+  await healthRoutes(app, store);
+  await suggestionsRoutes(app, store);
+  return app;
+}
+
+describe("repository insight route authorization", () => {
+  it("does not generate an embedding for another repository's memory", async () => {
+    const store = buildStore();
+    store.getById.mockResolvedValue({
+      id: "memory-id",
+      orgId: "org-a",
+      repoId: "repo-b",
+      text: "private memory",
+    });
+    const app = await buildApp(store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/embeddings/generate/memory-id",
+      headers: { authorization: "Bearer valid-token" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+
+    await app.close();
+  });
+
+  it.each([
+    ["backfill embeddings", "POST", "/v1/embeddings/backfill", {
+      orgId: "org-a",
+      repoId: "repo-b",
+    }],
+    [
+      "read embedding stats",
+      "GET",
+      "/v1/embeddings/stats?orgId=org-a&repoId=repo-b",
+      undefined,
+    ],
+    [
+      "read suggestions",
+      "GET",
+      "/v1/suggestions?orgId=org-a&repoId=repo-b",
+      undefined,
+    ],
+    [
+      "read repository health",
+      "GET",
+      "/v1/health/repo?orgId=org-a&repoId=repo-b",
+      undefined,
+    ],
+  ] as const)(
+    "does not let a repository-scoped API key %s for another repository",
+    async (_name, method, url, payload) => {
+      const store = buildStore();
+      const app = await buildApp(store);
+
+      const response = await app.inject({
+        method,
+        url,
+        headers: { authorization: "Bearer valid-token" },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.json()).toEqual({ error: "Forbidden" });
+      expect(store.getEmbeddingStats).not.toHaveBeenCalled();
+      expect(store.getMemoriesWithoutEmbeddings).not.toHaveBeenCalled();
+      expect(store.getUsageStats).not.toHaveBeenCalled();
+      expect(store.stats).not.toHaveBeenCalled();
+      expect(store.list).not.toHaveBeenCalled();
+
+      await app.close();
+    },
+  );
+});

--- a/apps/api/src/__tests__/stats.test.ts
+++ b/apps/api/src/__tests__/stats.test.ts
@@ -1,6 +1,7 @@
 import Fastify from "fastify";
 import { describe, expect, it, vi } from "vitest";
 import type { RemoteStore } from "unforgit-db";
+import { createAuthMiddleware } from "../middleware/auth.js";
 import { statsRoutes } from "../routes/stats.js";
 
 function buildStore() {
@@ -10,6 +11,12 @@ function buildStore() {
     weeklyTrend: vi.fn(),
     topTags: vi.fn(),
     stats: vi.fn(),
+    validateApiKey: vi.fn().mockResolvedValue({
+      id: "key-id",
+      orgId: "org",
+      repoId: "repo",
+      name: "test-key",
+    }),
   } as unknown as RemoteStore & {
     dailyCounts: ReturnType<typeof vi.fn>;
     hourlyCounts: ReturnType<typeof vi.fn>;
@@ -21,6 +28,7 @@ function buildStore() {
 
 async function buildStatsApp(store: RemoteStore) {
   const app = Fastify();
+  app.addHook("onRequest", createAuthMiddleware(store));
   await statsRoutes(app, store);
   return app;
 }
@@ -33,6 +41,7 @@ describe("stats routes", () => {
     const response = await app.inject({
       method: "GET",
       url: "/v1/stats/activity?orgId=org&repoId=repo&days=not-a-number",
+      headers: { authorization: "Bearer valid-token" },
     });
 
     expect(response.statusCode).toBe(400);
@@ -54,6 +63,7 @@ describe("stats routes", () => {
     const response = await app.inject({
       method: "GET",
       url: "/v1/stats/tags?orgId=org&repoId=repo&limit=0",
+      headers: { authorization: "Bearer valid-token" },
     });
 
     expect(response.statusCode).toBe(400);
@@ -61,6 +71,29 @@ describe("stats routes", () => {
       error: "Bad Request",
       message: "limit must be a positive integer",
     });
+    expect(store.topTags).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it.each([
+    ["overview", "/v1/stats?orgId=org&repoId=other"],
+    ["activity", "/v1/stats/activity?orgId=org&repoId=other"],
+    ["tags", "/v1/stats/tags?orgId=org&repoId=other"],
+  ])("does not expose %s for another repository", async (_name, url) => {
+    const store = buildStore();
+    const app = await buildStatsApp(store);
+
+    const response = await app.inject({
+      method: "GET",
+      url,
+      headers: { authorization: "Bearer valid-token" },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.stats).not.toHaveBeenCalled();
+    expect(store.dailyCounts).not.toHaveBeenCalled();
     expect(store.topTags).not.toHaveBeenCalled();
 
     await app.close();

--- a/apps/api/src/routes/authorization.ts
+++ b/apps/api/src/routes/authorization.ts
@@ -1,0 +1,21 @@
+import type { FastifyRequest } from "fastify";
+import type { Memory } from "unforgit-shared";
+
+export function hasRepositoryAccess(
+  apiKey: FastifyRequest["apiKey"],
+  orgId: string,
+  repoId: string,
+): boolean {
+  return (
+    apiKey?.orgId.toLowerCase() === orgId.toLowerCase() &&
+    (apiKey.repoId === null ||
+      apiKey.repoId.toLowerCase() === repoId.toLowerCase())
+  );
+}
+
+export function hasMemoryAccess(
+  apiKey: FastifyRequest["apiKey"],
+  memory: Pick<Memory, "orgId" | "repoId">,
+): boolean {
+  return hasRepositoryAccess(apiKey, memory.orgId, memory.repoId);
+}

--- a/apps/api/src/routes/embeddings.ts
+++ b/apps/api/src/routes/embeddings.ts
@@ -2,6 +2,10 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import type { RemoteStore } from "unforgit-db";
 import { isOpenAIConfigured } from "unforgit-core";
+import {
+  hasMemoryAccess,
+  hasRepositoryAccess,
+} from "./authorization.js";
 
 const backfillSchema = z.object({
   orgId: z.string(),
@@ -15,18 +19,22 @@ export async function embeddingRoutes(
   store: RemoteStore
 ): Promise<void> {
   app.post("/v1/embeddings/generate/:memoryId", async (request, reply) => {
-    if (!isOpenAIConfigured()) {
-      return reply.status(503).send({
-        error: "OpenAI API key not configured on server",
-        hint: "Set OPENAI_API_KEY environment variable on the server",
-      });
-    }
-
     const { memoryId } = request.params as { memoryId: string };
 
     const memory = await store.getById(memoryId);
     if (!memory) {
       return reply.status(404).send({ error: "Memory not found" });
+    }
+
+    if (!hasMemoryAccess(request.apiKey, memory)) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
+
+    if (!isOpenAIConfigured()) {
+      return reply.status(503).send({
+        error: "OpenAI API key not configured on server",
+        hint: "Set OPENAI_API_KEY environment variable on the server",
+      });
     }
 
     const hasExisting = await store.hasEmbedding(memoryId);
@@ -54,19 +62,23 @@ export async function embeddingRoutes(
   });
 
   app.post("/v1/embeddings/backfill", async (request, reply) => {
-    if (!isOpenAIConfigured()) {
-      return reply.status(503).send({
-        error: "OpenAI API key not configured on server",
-        hint: "Set OPENAI_API_KEY environment variable on the server",
-      });
-    }
-
     const parsed = backfillSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.status(400).send({ error: parsed.error.issues });
     }
 
     const { orgId, repoId, batchSize, limit } = parsed.data;
+
+    if (!hasRepositoryAccess(request.apiKey, orgId, repoId)) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
+
+    if (!isOpenAIConfigured()) {
+      return reply.status(503).send({
+        error: "OpenAI API key not configured on server",
+        hint: "Set OPENAI_API_KEY environment variable on the server",
+      });
+    }
 
     const memories = await store.getMemoriesWithoutEmbeddings(orgId, repoId);
     const toProcess = limit ? memories.slice(0, limit) : memories;
@@ -122,6 +134,10 @@ export async function embeddingRoutes(
       return reply.status(400).send({
         error: "Missing required query parameters: orgId, repoId",
       });
+    }
+
+    if (!hasRepositoryAccess(request.apiKey, query.orgId, query.repoId)) {
+      return reply.status(403).send({ error: "Forbidden" });
     }
 
     const stats = await store.getEmbeddingStats(query.orgId, query.repoId);

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import type { RemoteStore } from "unforgit-db";
 import { isOpenAIConfigured } from "unforgit-core";
+import { hasRepositoryAccess } from "./authorization.js";
 
 const healthQuerySchema = z.object({
   orgId: z.string(),
@@ -47,6 +48,10 @@ export async function healthRoutes(
     }
 
     const { orgId, repoId } = parsed.data;
+
+    if (!hasRepositoryAccess(request.apiKey, orgId, repoId)) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
 
     const [stats, embeddingStats, usageStats, activeMemories] = await Promise.all([
       store.stats(orgId, repoId),

--- a/apps/api/src/routes/stats.ts
+++ b/apps/api/src/routes/stats.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { RemoteStore } from "unforgit-db";
+import { hasRepositoryAccess } from "./authorization.js";
 
 interface StatsQuery {
   orgId: string;
@@ -70,6 +71,10 @@ export async function statsRoutes(
         });
       }
 
+      if (!hasRepositoryAccess(request.apiKey, orgId, repoId)) {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
+
       const stats = await store.stats(orgId, repoId);
 
       return reply.send({
@@ -89,6 +94,10 @@ export async function statsRoutes(
           error: "Bad Request",
           message: "orgId and repoId are required",
         });
+      }
+
+      if (!hasRepositoryAccess(request.apiKey, orgId, repoId)) {
+        return reply.status(403).send({ error: "Forbidden" });
       }
 
       const days = parsePositiveIntegerParam(daysStr, 365);
@@ -126,6 +135,10 @@ export async function statsRoutes(
           error: "Bad Request",
           message: "orgId and repoId are required",
         });
+      }
+
+      if (!hasRepositoryAccess(request.apiKey, orgId, repoId)) {
+        return reply.status(403).send({ error: "Forbidden" });
       }
 
       const limit = parsePositiveIntegerParam(limitStr, 20);

--- a/apps/api/src/routes/suggestions.ts
+++ b/apps/api/src/routes/suggestions.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import type { RemoteStore } from "unforgit-db";
 import { findConsolidationCandidatesRemote } from "unforgit-core";
+import { hasRepositoryAccess } from "./authorization.js";
 
 interface Suggestion {
   type:
@@ -37,6 +38,10 @@ export async function suggestionsRoutes(
     }
 
     const { orgId, repoId, limit } = parsed.data;
+
+    if (!hasRepositoryAccess(request.apiKey, orgId, repoId)) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
 
     const suggestions: Suggestion[] = [];
 


### PR DESCRIPTION
## Summary
- enforce API-key organization/repository scope on stats, suggestions, and repository health routes
- enforce scope before embedding generation, backfill, or stats operations
- add cross-repository authorization regression coverage

## Verification
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `pnpm lint` (21 existing warnings, 0 errors)
- `pnpm test` (54 files, 278 tests)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --json` (0 vulnerabilities)
- `docker compose down && docker compose up -d --build`; API health, admin, and website HTTP checks passed