### PR TITLE
fix(api): authorize sync tombstone targets

### DIFF
--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -98,6 +98,43 @@ describe("sync routes", () => {
     await app.close();
   });
 
+  it("does not let a repository-scoped API key tombstone another repository's memory", async () => {
+    const store = buildStore();
+    store.validateApiKey.mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    });
+    store.getById.mockResolvedValue({
+      id: "memory-id",
+      orgId: "org-a",
+      repoId: "repo-b",
+    });
+
+    const app = Fastify();
+    app.addHook("onRequest", createAuthMiddleware(store));
+    await app.register(syncRoutes, { store });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/sync/tombstones",
+      headers: { authorization: "Bearer valid-token" },
+      payload: {
+        memoryId: "memory-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        deletedAt: new Date().toISOString(),
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.applyTombstone).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
   it.each([
     ["/v1/sync/pull?orgId=org-a&repoId=repo-b", "list"],
     ["/v1/sync/tombstones?orgId=org-a&repoId=repo-b", "getUnsyncedTombstones"],

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -199,6 +199,11 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         return reply.status(403).send({ error: "Forbidden" });
       }
 
+      const memory = await store.getById(body.memoryId);
+      if (memory && !hasApiKeyScope(request, memory.orgId, memory.repoId)) {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
+
       const tombstone: Tombstone = {
         id: crypto.randomUUID(),
         memoryId: body.memoryId,


### PR DESCRIPTION
## Summary
- check the stored target memory scope before applying a sync tombstone
- prevent repository-scoped API keys from deleting memories in another repository by pairing a foreign memory ID with an authorized payload scope
- add cross-repository regression coverage

## Verification
- `pnpm exec vitest run apps/api/src/__tests__/sync.test.ts` (10 tests)
- `pnpm lint` (0 errors; 21 pre-existing warnings)
- `pnpm test` (54 files, 279 tests)
- `pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --audit-level high`
- `docker compose down && docker compose up -d --build`
- API health check: OK