### PR TITLE
fix: enforce sync push target scope

### DIFF
--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -98,6 +98,50 @@ describe("sync routes", () => {
     await app.close();
   });
 
+  it("does not let a repository-scoped API key overwrite another repository's memory via sync push", async () => {
+    const store = buildStore();
+    store.validateApiKey.mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    });
+    store.getById.mockResolvedValue({
+      id: "memory-id",
+      orgId: "org-a",
+      repoId: "repo-b",
+    });
+    store.upsertFromLocal.mockResolvedValue({ action: "updated", conflict: false });
+
+    const app = Fastify();
+    app.addHook("onRequest", createAuthMiddleware(store));
+    await app.register(syncRoutes, { store });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/sync/push",
+      headers: { authorization: "Bearer valid-token" },
+      payload: {
+        id: "memory-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        memoryType: "semantic",
+        visibility: "private",
+        status: "active",
+        text: "overwritten",
+        version: 100,
+        createdAt: "2026-08-23T00:00:00.000Z",
+        updatedAt: "2026-08-23T00:00:00.000Z",
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.upsertFromLocal).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
   it("does not let a repository-scoped API key tombstone another repository's memory", async () => {
     const store = buildStore();
     store.validateApiKey.mockResolvedValue({

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -117,6 +117,11 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         return reply.status(403).send({ error: "Forbidden" });
       }
 
+      const existing = await store.getById(body.id);
+      if (existing && !hasApiKeyScope(request, existing.orgId, existing.repoId)) {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
+
       const memory: Memory = {
         id: body.id,
         orgId: body.orgId,


### PR DESCRIPTION
## Summary
- authorize an existing sync-push target by its stored repository scope
- reject cross-repository UUID collisions before any upsert
- add a regression test proving repository-scoped keys cannot overwrite foreign memories

## Validation
- `pnpm exec vitest run apps/api/src/__tests__/sync.test.ts` (11 passed)
- `pnpm test` (54 files, 280 tests passed)
- `pnpm lint` (0 errors; 21 pre-existing warnings)
- `pnpm build`
- `docker compose down && docker compose up -d --build`
- `curl http://127.0.0.1:3737/health`