### PR TITLE
fix(api): validate sync inputs

### DIFF
--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -9,6 +9,8 @@ function buildStore() {
     applyTombstone: vi.fn(),
     getAllLinks: vi.fn(),
     getById: vi.fn(),
+    getModifiedSince: vi.fn(),
+    getTombstones: vi.fn(),
     getUnsyncedTombstones: vi.fn(),
     hardDelete: vi.fn(),
     list: vi.fn(),
@@ -19,6 +21,8 @@ function buildStore() {
     applyTombstone: ReturnType<typeof vi.fn>;
     getAllLinks: ReturnType<typeof vi.fn>;
     getById: ReturnType<typeof vi.fn>;
+    getModifiedSince: ReturnType<typeof vi.fn>;
+    getTombstones: ReturnType<typeof vi.fn>;
     getUnsyncedTombstones: ReturnType<typeof vi.fn>;
     hardDelete: ReturnType<typeof vi.fn>;
     list: ReturnType<typeof vi.fn>;
@@ -64,6 +68,100 @@ describe("sync routes", () => {
 
     await app.close();
   });
+
+  it.each([
+    [
+      "/v1/sync/pull?orgId=org-a&repoId=repo-a&since=invalid",
+      "getModifiedSince",
+    ],
+    [
+      "/v1/sync/tombstones?orgId=org-a&repoId=repo-a&since=invalid",
+      "getTombstones",
+    ],
+  ] as const)("rejects an invalid sync date in %s", async (url, storeMethod) => {
+    const store = buildStore();
+    const app = await buildSyncApp(store);
+
+    const response = await app.inject({ method: "GET", url });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({ error: "since must be a valid date" });
+    expect(store[storeMethod]).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it.each([
+    ["/v1/sync/push", "upsertFromLocal", { id: "memory-id" }],
+    ["/v1/sync/tombstones", "applyTombstone", { memoryId: "memory-id" }],
+  ] as const)(
+    "rejects an incomplete body for %s",
+    async (url, storeMethod, payload) => {
+      const store = buildStore();
+      const app = await buildSyncApp(store);
+
+      const response = await app.inject({ method: "POST", url, payload });
+
+      expect(response.statusCode).toBe(400);
+      expect(store[storeMethod]).not.toHaveBeenCalled();
+
+      await app.close();
+    },
+  );
+
+  it.each([
+    [
+      "/v1/sync/push",
+      "upsertFromLocal",
+      {
+        id: "memory-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        memoryType: "semantic",
+        visibility: "private",
+        status: "active",
+        text: "memory",
+        createdAt: "invalid",
+        updatedAt: "2026-08-24T00:00:00.000Z",
+      },
+    ],
+    [
+      "/v1/sync/tombstones",
+      "applyTombstone",
+      {
+        memoryId: "memory-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        deletedAt: "invalid",
+      },
+    ],
+  ] as const)(
+    "rejects an invalid body date for %s",
+    async (url, storeMethod, payload) => {
+      const store = buildStore();
+      store.validateApiKey.mockResolvedValue({
+        id: "key-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        name: "test-key",
+      });
+      const app = Fastify();
+      app.addHook("onRequest", createAuthMiddleware(store));
+      await app.register(syncRoutes, { store });
+
+      const response = await app.inject({
+        method: "POST",
+        url,
+        headers: { authorization: "Bearer valid-token" },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(store[storeMethod]).not.toHaveBeenCalled();
+
+      await app.close();
+    },
+  );
 
   it("does not let a repository-scoped API key hard-delete another repository's memory", async () => {
     const store = buildStore();

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -51,6 +51,23 @@ function hasApiKeyScope(
   );
 }
 
+function parseDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function hasRequiredStrings(
+  value: object,
+  fields: readonly string[],
+): boolean {
+  const record = value as Record<string, unknown>;
+  return fields.every(
+    (field) => typeof record[field] === "string" && record[field].length > 0,
+  );
+}
+
 export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
   app,
   { store },
@@ -64,13 +81,18 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         return reply.status(400).send({ error: "orgId and repoId are required" });
       }
 
+      const sinceDate = since ? parseDate(since) : undefined;
+      if (since && !sinceDate) {
+        return reply.status(400).send({ error: "since must be a valid date" });
+      }
+
       if (!hasApiKeyScope(request, orgId, repoId)) {
         return reply.status(403).send({ error: "Forbidden" });
       }
 
       let memories: Memory[];
-      if (since) {
-        memories = await store.getModifiedSince(orgId, repoId, new Date(since));
+      if (sinceDate) {
+        memories = await store.getModifiedSince(orgId, repoId, sinceDate);
       } else {
         memories = await store.list({
           orgId,
@@ -109,12 +131,35 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     async (request, reply) => {
       const body = request.body;
 
-      if (!body) {
-        return reply.status(400).send({ error: "Request body is required" });
+      if (!body || !hasRequiredStrings(body, ["orgId", "repoId"])) {
+        return reply.status(400).send({ error: "Invalid sync push body" });
       }
 
       if (!hasApiKeyScope(request, body.orgId, body.repoId)) {
         return reply.status(403).send({ error: "Forbidden" });
+      }
+
+      if (
+        !hasRequiredStrings(body, [
+          "id",
+          "memoryType",
+          "visibility",
+          "status",
+          "text",
+          "createdAt",
+          "updatedAt",
+        ])
+      ) {
+        return reply.status(400).send({ error: "Invalid sync push body" });
+      }
+
+      const createdAt = parseDate(body.createdAt);
+      const updatedAt = parseDate(body.updatedAt);
+      const deletedAt = body.deletedAt ? parseDate(body.deletedAt) : undefined;
+      if (!createdAt || !updatedAt || (body.deletedAt && !deletedAt)) {
+        return reply.status(400).send({
+          error: "createdAt, updatedAt, and deletedAt must be valid dates",
+        });
       }
 
       const existing = await store.getById(body.id);
@@ -138,10 +183,10 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         ttlSeconds: body.ttlSeconds,
         supersedesId: body.supersedesId,
         version: body.version ?? 1,
-        deletedAt: body.deletedAt ? new Date(body.deletedAt) : undefined,
+        deletedAt,
         deletedBy: body.deletedBy,
-        createdAt: new Date(body.createdAt),
-        updatedAt: new Date(body.updatedAt),
+        createdAt,
+        updatedAt,
       };
 
       const result = await store.upsertFromLocal(memory);
@@ -171,12 +216,17 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         return reply.status(400).send({ error: "orgId and repoId are required" });
       }
 
+      const sinceDate = since ? parseDate(since) : undefined;
+      if (since && !sinceDate) {
+        return reply.status(400).send({ error: "since must be a valid date" });
+      }
+
       if (!hasApiKeyScope(request, orgId, repoId)) {
         return reply.status(403).send({ error: "Forbidden" });
       }
 
-      const tombstones = since
-        ? await store.getTombstones(orgId, repoId, new Date(since))
+      const tombstones = sinceDate
+        ? await store.getTombstones(orgId, repoId, sinceDate)
         : await store.getUnsyncedTombstones(orgId, repoId);
 
       return reply.send(tombstones.map((t) => ({
@@ -196,12 +246,21 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     async (request, reply) => {
       const body = request.body;
 
-      if (!body) {
-        return reply.status(400).send({ error: "Request body is required" });
+      if (!body || !hasRequiredStrings(body, ["orgId", "repoId"])) {
+        return reply.status(400).send({ error: "Invalid tombstone body" });
       }
 
       if (!hasApiKeyScope(request, body.orgId, body.repoId)) {
         return reply.status(403).send({ error: "Forbidden" });
+      }
+
+      if (!hasRequiredStrings(body, ["memoryId", "deletedAt"])) {
+        return reply.status(400).send({ error: "Invalid tombstone body" });
+      }
+
+      const deletedAt = parseDate(body.deletedAt);
+      if (!deletedAt) {
+        return reply.status(400).send({ error: "deletedAt must be a valid date" });
       }
 
       const memory = await store.getById(body.memoryId);
@@ -214,7 +273,7 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         memoryId: body.memoryId,
         orgId: body.orgId,
         repoId: body.repoId,
-        deletedAt: new Date(body.deletedAt),
+        deletedAt,
         deletedBy: body.deletedBy,
       };
 


### PR DESCRIPTION
## Summary
- reject invalid `since` values on sync pull and tombstone reads
- reject incomplete sync push/tombstone payloads before store calls
- validate sync timestamps and add regression coverage

## Verification
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `pnpm lint` (passes with 21 existing warnings)
- `pnpm test` (54 files, 286 tests)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --audit-level low` (0 vulnerabilities)
- `docker compose down && docker compose up -d --build`; API, website, and admin HTTP checks pass