### PR TITLE
fix(api): validate log query inputs

### DIFF
--- a/apps/api/src/__tests__/admin-auth.test.ts
+++ b/apps/api/src/__tests__/admin-auth.test.ts
@@ -16,6 +16,10 @@ function buildStore() {
     hourlyCounts: vi.fn(),
     weeklyTrend: vi.fn(),
     topTags: vi.fn(),
+    list: vi.fn(),
+    count: vi.fn(),
+    getApiKeyLogs: vi.fn(),
+    countApiKeyLogs: vi.fn(),
   } as unknown as RemoteStore & {
     listApiKeysWithUsers: ReturnType<typeof vi.fn>;
     createApiKey: ReturnType<typeof vi.fn>;
@@ -27,6 +31,10 @@ function buildStore() {
     hourlyCounts: ReturnType<typeof vi.fn>;
     weeklyTrend: ReturnType<typeof vi.fn>;
     topTags: ReturnType<typeof vi.fn>;
+    list: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+    getApiKeyLogs: ReturnType<typeof vi.fn>;
+    countApiKeyLogs: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -191,6 +199,53 @@ describe("admin auth", () => {
 
     await app.close();
   });
+
+  it("rejects invalid admin memory pagination before querying the store", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    const store = buildStore();
+    const token = await signAdminToken();
+    const app = await buildAdminApp(store);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/admin/repos/org-id/repo-id/memories?limit=nope&offset=-1",
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({ error: "Bad Request" });
+    expect(store.list).not.toHaveBeenCalled();
+    expect(store.count).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it.each([
+    "/v1/admin/logs?since=not-a-date",
+    "/v1/admin/logs/key/key-id?limit=0",
+    "/v1/admin/logs/repo/org-id/repo-id?offset=-1",
+  ])(
+    "rejects invalid admin log filters before querying the store: %s",
+    async (url) => {
+      process.env.JWT_SECRET = "test-secret";
+      const store = buildStore();
+      const token = await signAdminToken();
+      const app = await buildAdminApp(store);
+
+      const response = await app.inject({
+        method: "GET",
+        url,
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toMatchObject({ error: "Bad Request" });
+      expect(store.getApiKeyLogs).not.toHaveBeenCalled();
+      expect(store.countApiKeyLogs).not.toHaveBeenCalled();
+
+      await app.close();
+    },
+  );
 
   it("returns a bad request instead of crashing when manually consolidating without a body", async () => {
     process.env.JWT_SECRET = "test-secret";

--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -204,4 +204,41 @@ describe("auth routes", () => {
 
     await app.close();
   });
+
+  it.each([
+    "/v1/auth/me/logs?until=not-a-date",
+    "/v1/auth/me/logs/repo/allowed-org/allowed-repo?limit=0&offset=-1",
+  ])(
+    "rejects invalid user log filters before querying logs: %s",
+    async (url) => {
+      process.env.JWT_SECRET = "test-secret";
+      const store = {
+        getUserApiKeys: vi.fn().mockResolvedValue([
+          { id: "key-id", orgId: "allowed-org", repoId: "allowed-repo" },
+        ]),
+        getApiKeyLogs: vi.fn(),
+        countApiKeyLogs: vi.fn(),
+      } as unknown as RemoteStore & {
+        getUserApiKeys: ReturnType<typeof vi.fn>;
+        getApiKeyLogs: ReturnType<typeof vi.fn>;
+        countApiKeyLogs: ReturnType<typeof vi.fn>;
+      };
+      const token = await signUserToken();
+      const app = await buildApp(store);
+
+      const response = await app.inject({
+        method: "GET",
+        url,
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toMatchObject({ error: "Bad Request" });
+      expect(store.getUserApiKeys).not.toHaveBeenCalled();
+      expect(store.getApiKeyLogs).not.toHaveBeenCalled();
+      expect(store.countApiKeyLogs).not.toHaveBeenCalled();
+
+      await app.close();
+    },
+  );
 });

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -107,6 +107,47 @@ function parsePositiveInteger(value: string | undefined): number | undefined {
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+function parseNonNegativeInteger(value: string | undefined): number | undefined {
+  if (value === undefined || !/^\d+$/.test(value)) return undefined;
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function parseOptionalDate(value: string | undefined): Date | null | undefined {
+  if (value === undefined) return undefined;
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+interface LogQuery {
+  operation?: string;
+  since?: string;
+  until?: string;
+  limit?: string;
+  offset?: string;
+}
+
+function parseLogQuery(query: LogQuery): {
+  operation?: string;
+  since?: Date;
+  until?: Date;
+  limit: number;
+  offset: number;
+} | null {
+  const since = parseOptionalDate(query.since);
+  const until = parseOptionalDate(query.until);
+  const limit = query.limit ? parsePositiveInteger(query.limit) : 100;
+  const offset = query.offset ? parseNonNegativeInteger(query.offset) : 0;
+
+  if (since === null || until === null || limit === undefined || offset === undefined) {
+    return null;
+  }
+
+  return { operation: query.operation, since, until, limit, offset };
+}
+
 export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
   app,
   { store },
@@ -458,6 +499,18 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     async (request, reply) => {
       const { orgId, repoId } = request.params;
       const query = request.query as Record<string, string>;
+      const limit = query.limit ? parsePositiveInteger(query.limit) : 50;
+      const offset = query.offset
+        ? parseNonNegativeInteger(query.offset)
+        : 0;
+
+      if (limit === undefined || offset === undefined) {
+        return reply.status(400).send({
+          error: "Bad Request",
+          message:
+            "limit must be a positive integer and offset must be a non-negative integer",
+        });
+      }
 
       const listQuery = {
         orgId,
@@ -466,8 +519,8 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         status: query.status?.split(",").filter(Boolean),
         tags: query.tags?.split(",").filter(Boolean),
         search: query.search,
-        limit: query.limit ? parseInt(query.limit, 10) : 50,
-        offset: query.offset ? parseInt(query.offset, 10) : 0,
+        limit,
+        offset,
         sortBy: query.sortBy ?? "createdAt",
         sortOrder: query.sortOrder ?? "desc",
       };
@@ -751,17 +804,22 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     { preHandler: adminAuthPreHandler },
     async (request, reply) => {
       const query = request.query;
+      const parsedQuery = parseLogQuery(query);
+
+      if (!parsedQuery) {
+        return reply.status(400).send({
+          error: "Bad Request",
+          message:
+            "since and until must be valid dates, limit must be a positive integer, and offset must be a non-negative integer",
+        });
+      }
 
       try {
         const filters = {
           apiKeyId: query.apiKeyId,
           orgId: query.orgId,
           repoId: query.repoId,
-          operation: query.operation,
-          since: query.since ? new Date(query.since) : undefined,
-          until: query.until ? new Date(query.until) : undefined,
-          limit: query.limit ? parseInt(query.limit, 10) : 100,
-          offset: query.offset ? parseInt(query.offset, 10) : 0,
+          ...parsedQuery,
         };
 
         const [logs, total] = await Promise.all([
@@ -794,15 +852,20 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     async (request, reply) => {
       const { keyId } = request.params;
       const query = request.query;
+      const parsedQuery = parseLogQuery(query);
+
+      if (!parsedQuery) {
+        return reply.status(400).send({
+          error: "Bad Request",
+          message:
+            "since and until must be valid dates, limit must be a positive integer, and offset must be a non-negative integer",
+        });
+      }
 
       try {
         const filters = {
           apiKeyId: keyId,
-          operation: query.operation,
-          since: query.since ? new Date(query.since) : undefined,
-          until: query.until ? new Date(query.until) : undefined,
-          limit: query.limit ? parseInt(query.limit, 10) : 100,
-          offset: query.offset ? parseInt(query.offset, 10) : 0,
+          ...parsedQuery,
         };
 
         const [logs, total] = await Promise.all([
@@ -835,16 +898,21 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     async (request, reply) => {
       const { orgId, repoId } = request.params;
       const query = request.query;
+      const parsedQuery = parseLogQuery(query);
+
+      if (!parsedQuery) {
+        return reply.status(400).send({
+          error: "Bad Request",
+          message:
+            "since and until must be valid dates, limit must be a positive integer, and offset must be a non-negative integer",
+        });
+      }
 
       try {
         const filters = {
           orgId,
           repoId,
-          operation: query.operation,
-          since: query.since ? new Date(query.since) : undefined,
-          until: query.until ? new Date(query.until) : undefined,
-          limit: query.limit ? parseInt(query.limit, 10) : 100,
-          offset: query.offset ? parseInt(query.offset, 10) : 0,
+          ...parsedQuery,
         };
 
         const [logs, total] = await Promise.all([

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -83,6 +83,54 @@ async function createUserToken(user: {
     .sign(secret);
 }
 
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  if (value === undefined || !/^\d+$/.test(value)) return undefined;
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseNonNegativeInteger(value: string | undefined): number | undefined {
+  if (value === undefined || !/^\d+$/.test(value)) return undefined;
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function parseOptionalDate(value: string | undefined): Date | null | undefined {
+  if (value === undefined) return undefined;
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+interface LogQuery {
+  operation?: string;
+  since?: string;
+  until?: string;
+  limit?: string;
+  offset?: string;
+}
+
+function parseLogQuery(query: LogQuery): {
+  operation?: string;
+  since?: Date;
+  until?: Date;
+  limit: number;
+  offset: number;
+} | null {
+  const since = parseOptionalDate(query.since);
+  const until = parseOptionalDate(query.until);
+  const limit = query.limit ? parsePositiveInteger(query.limit) : 100;
+  const offset = query.offset ? parseNonNegativeInteger(query.offset) : 0;
+
+  if (since === null || until === null || limit === undefined || offset === undefined) {
+    return null;
+  }
+
+  return { operation: query.operation, since, until, limit, offset };
+}
+
 export async function verifyUserToken(
   token: string
 ): Promise<{ id: string; githubId: number; githubLogin: string; isAdmin: boolean } | null> {
@@ -521,6 +569,17 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
       });
     }
 
+    const query = request.query;
+    const parsedQuery = parseLogQuery(query);
+
+    if (!parsedQuery) {
+      return reply.status(400).send({
+        error: "Bad Request",
+        message:
+          "since and until must be valid dates, limit must be a positive integer, and offset must be a non-negative integer",
+      });
+    }
+
     const userApiKeys = await store.getUserApiKeys(payload.id);
     const apiKeyIds = userApiKeys.map((k) => k.id);
 
@@ -528,14 +587,9 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
       return reply.send({ logs: [], total: 0 });
     }
 
-    const query = request.query;
     const filters = {
       apiKeyIds,
-      operation: query.operation,
-      since: query.since ? new Date(query.since) : undefined,
-      until: query.until ? new Date(query.until) : undefined,
-      limit: query.limit ? parseInt(query.limit, 10) : 100,
-      offset: query.offset ? parseInt(query.offset, 10) : 0,
+      ...parsedQuery,
     };
 
     try {
@@ -593,6 +647,17 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
       });
     }
 
+    const query = request.query;
+    const parsedQuery = parseLogQuery(query);
+
+    if (!parsedQuery) {
+      return reply.status(400).send({
+        error: "Bad Request",
+        message:
+          "since and until must be valid dates, limit must be a positive integer, and offset must be a non-negative integer",
+      });
+    }
+
     const { orgId, repoId } = request.params;
     const userApiKeys = await store.getUserApiKeys(payload.id);
     const apiKeyIds = userApiKeys
@@ -603,16 +668,11 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
       return reply.send({ logs: [], total: 0 });
     }
 
-    const query = request.query;
     const filters = {
       apiKeyIds,
       orgId,
       repoId,
-      operation: query.operation,
-      since: query.since ? new Date(query.since) : undefined,
-      until: query.until ? new Date(query.until) : undefined,
-      limit: query.limit ? parseInt(query.limit, 10) : 100,
-      offset: query.offset ? parseInt(query.offset, 10) : 0,
+      ...parsedQuery,
     };
 
     try {


### PR DESCRIPTION
## Summary
- reject malformed date, limit, and offset filters on authenticated user and admin log routes
- reject malformed pagination on admin memory listing
- add regression coverage for every affected route before store calls

## Verification
- `pnpm install --frozen-lockfile`
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm db:generate`
- `pnpm lint` (passes with 21 pre-existing warnings)
- `pnpm test` (54 files, 292 tests)
- `DATABASE_URL=postgresql://unforgit:unforgit@localhost:5432/unforgit pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --json` (0 vulnerabilities before and after)
- `docker compose down && docker compose up -d --build`; API, admin, website, and PostgreSQL verified healthy/reachable