### PR TITLE
fix(api): validate delete request body

### DIFF
--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -15,6 +15,7 @@ function buildStore() {
     hardDelete: vi.fn(),
     list: vi.fn(),
     restore: vi.fn(),
+    softDelete: vi.fn(),
     upsertFromLocal: vi.fn(),
     validateApiKey: vi.fn(),
   } as unknown as RemoteStore & {
@@ -27,6 +28,7 @@ function buildStore() {
     hardDelete: ReturnType<typeof vi.fn>;
     list: ReturnType<typeof vi.fn>;
     restore: ReturnType<typeof vi.fn>;
+    softDelete: ReturnType<typeof vi.fn>;
     upsertFromLocal: ReturnType<typeof vi.fn>;
     validateApiKey: ReturnType<typeof vi.fn>;
   };
@@ -192,6 +194,24 @@ describe("sync routes", () => {
     expect(response.statusCode).toBe(403);
     expect(response.json()).toEqual({ error: "Forbidden" });
     expect(store.hardDelete).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("rejects a non-boolean hard-delete flag before calling the store", async () => {
+    const store = buildStore();
+    const app = await buildSyncApp(store);
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/v1/memory/memory-id",
+      payload: { hardDelete: "false" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(store.getById).not.toHaveBeenCalled();
+    expect(store.hardDelete).not.toHaveBeenCalled();
+    expect(store.softDelete).not.toHaveBeenCalled();
 
     await app.close();
   });

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -1,6 +1,6 @@
 import type { FastifyPluginAsync, FastifyRequest } from "fastify";
 import { RemoteStore } from "unforgit-db";
-import type { Memory, Tombstone } from "unforgit-shared";
+import { deleteMemorySchema, type Memory, type Tombstone } from "unforgit-shared";
 
 interface SyncQueryParams {
   orgId: string;
@@ -291,7 +291,12 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     "/v1/memory/:id",
     async (request, reply) => {
       const { id } = request.params;
-      const { deletedBy, hardDelete } = request.body ?? {};
+      const parsed = deleteMemorySchema.safeParse(request.body ?? {});
+      if (!parsed.success) {
+        return reply.status(400).send({ error: parsed.error.issues });
+      }
+
+      const { deletedBy, hardDelete } = parsed.data;
       const memory = await store.getById(id);
 
       if (!memory) {


### PR DESCRIPTION
## Summary
- validate DELETE `/v1/memory/:id` payloads with the shared schema
- reject malformed `hardDelete` values before any store access
- prevent truthy strings such as `"false"` from causing irreversible deletion

## Tests
- `pnpm exec vitest run apps/api/src/__tests__/sync.test.ts`
- `pnpm test` (55 files, 297 tests)
- tracked-source ESLint (0 errors; 24 existing warnings)
- `DATABASE_URL=... pnpm build`
- `pnpm smoke:cli`
- `pnpm audit --audit-level high`
- `docker compose down && docker compose up -d --build`
- API, website, and admin HTTP health checks