### PR TITLE
fix(lint): ignore generated agent worktrees

### DIFF
--- a/apps/cli/src/__tests__/eslint-config.test.ts
+++ b/apps/cli/src/__tests__/eslint-config.test.ts
@@ -1,0 +1,22 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ESLint } from "eslint";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
+const eslint = new ESLint({ cwd: repoRoot });
+
+describe("repository ESLint discovery", () => {
+  it.each([".awp-worktrees/stale/source.ts", ".awp-evidence/run/output.ts"])(
+    "ignores generated agent path %s",
+    async (relativePath) => {
+      await expect(eslint.isPathIgnored(path.join(repoRoot, relativePath))).resolves.toBe(true);
+    },
+  );
+
+  it("keeps tracked product source in lint discovery", async () => {
+    await expect(
+      eslint.isPathIgnored(path.join(repoRoot, "apps/api/src/index.ts")),
+    ).resolves.toBe(false);
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,8 @@ export default tseslint.config(
       "**/out/**",
       "**/build/**",
       "**/coverage/**",
+      "**/.awp-worktrees/**",
+      "**/.awp-evidence/**",
       "packages/db/src/generated/**",
       "**/next-env.d.ts",
     ],


### PR DESCRIPTION
## Summary

- exclude generated `.awp-worktrees/**` and `.awp-evidence/**` trees from the canonical ESLint traversal
- add a behavioral regression test that verifies both generated-tree ignores and continued lint coverage for tracked product source
- preserve all existing React and TypeScript rules and their canonical warnings

## Why

Local agent evidence and nested worktrees are not product source, but the repository-level lint command was recursively traversing them. Stale generated checkouts could therefore make a clean canonical checkout appear broken.

## Verification

- `pnpm exec vitest run apps/cli/src/__tests__/eslint-config.test.ts` — 3/3 passed
- `pnpm lint` — exit 0, 0 errors; existing canonical warnings remain visible
- `pnpm test` — 300 tests passed in the worker verification
- `pnpm build` — passed in the worker verification
- `git diff --check` — passed
- staged gitleaks scan — no leaks

## Draft status

This PR is opened as a draft while independent review and hosted CI complete. It must not be considered delivered until CI is green, the PR is merged, and `main` is verified.

Related to #46.
