### PR TITLE
fix(lint): remove recurring React warnings

### DIFF
--- a/apps/admin/app/page.tsx
+++ b/apps/admin/app/page.tsx
@@ -3,22 +3,19 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Github, Loader2 } from "lucide-react";
-import { getToken, getApiBaseUrl } from "@/lib/api";
+import { getApiBaseUrl } from "@/lib/api";
+import { useAdminAuthState } from "@/lib/auth-store";
 
 export default function LoginPage() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
+  const { hydrated, isAuthenticated } = useAdminAuthState();
 
   useEffect(() => {
-    if (getToken()) {
+    if (hydrated && isAuthenticated) {
       router.replace("/keys");
     }
-
-    const url = new URL(window.location.href);
-    if (url.searchParams.get("error")) {
-      setLoading(false);
-    }
-  }, [router]);
+  }, [hydrated, isAuthenticated, router]);
 
   const handleGitHubLogin = () => {
     setLoading(true);

--- a/apps/admin/components/auth-guard.tsx
+++ b/apps/admin/components/auth-guard.tsx
@@ -1,23 +1,20 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { getToken } from "@/lib/api";
+import { useAdminAuthState } from "@/lib/auth-store";
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter();
-  const [checked, setChecked] = useState(false);
+  const { hydrated, isAuthenticated } = useAdminAuthState();
 
   useEffect(() => {
-    const token = getToken();
-    if (!token) {
+    if (hydrated && !isAuthenticated) {
       router.replace("/");
-    } else {
-      setChecked(true);
     }
-  }, [router]);
+  }, [hydrated, isAuthenticated, router]);
 
-  if (!checked) {
+  if (!hydrated || !isAuthenticated) {
     return (
       <div className="flex h-full items-center justify-center">
         <div className="h-6 w-6 animate-spin rounded-full border-2 border-foreground border-t-transparent" />

--- a/apps/admin/components/header.tsx
+++ b/apps/admin/components/header.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
+import { useState, useMemo } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
 import { LogOut, Menu, X, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { getToken, clearToken, getUser, type User } from "@/lib/api";
+import { clearToken } from "@/lib/api";
+import { useAdminAuthState } from "@/lib/auth-store";
+import { isMobileMenuOpen, toggleMobileMenuPath } from "@unforgit/ui/utils";
 
 const adminNavItems = [
   { href: "/repos", label: "repos" },
@@ -23,22 +25,14 @@ const userNavItems = [
 export function Header() {
   const pathname = usePathname();
   const router = useRouter();
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [user, setUser] = useState<User | null>(null);
+  const [mobileOpenPath, setMobileOpenPath] = useState<string | null>(null);
+  const mobileOpen = isMobileMenuOpen(mobileOpenPath, pathname);
+  const { isAuthenticated, user } = useAdminAuthState();
 
   const navItems = useMemo(() => {
     return user?.isAdmin ? adminNavItems : userNavItems;
   }, [user?.isAdmin]);
 
-  useEffect(() => {
-    setMobileOpen(false);
-  }, [pathname]);
-
-  useEffect(() => {
-    setIsAuthenticated(!!getToken());
-    setUser(getUser());
-  }, [pathname]);
 
   const handleLogout = () => {
     clearToken();
@@ -109,7 +103,9 @@ export function Header() {
             {/* Mobile: hamburger */}
             <div className="flex md:hidden items-center gap-3">
               <button
-                onClick={() => setMobileOpen(!mobileOpen)}
+                onClick={() =>
+                  setMobileOpenPath((openPath) => toggleMobileMenuPath(openPath, pathname))
+                }
                 className="text-foreground/70 hover:text-foreground transition-colors p-1"
                 aria-label="Toggle menu"
               >

--- a/apps/admin/components/header.tsx
+++ b/apps/admin/components/header.tsx
@@ -8,7 +8,11 @@ import { LogOut, Menu, X, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { clearToken } from "@/lib/api";
 import { useAdminAuthState } from "@/lib/auth-store";
-import { isMobileMenuOpen, toggleMobileMenuPath } from "@unforgit/ui/utils";
+import {
+  createMobileMenuState,
+  syncMobileMenuState,
+  toggleMobileMenuState,
+} from "@unforgit/ui/utils";
 
 const adminNavItems = [
   { href: "/repos", label: "repos" },
@@ -25,8 +29,14 @@ const userNavItems = [
 export function Header() {
   const pathname = usePathname();
   const router = useRouter();
-  const [mobileOpenPath, setMobileOpenPath] = useState<string | null>(null);
-  const mobileOpen = isMobileMenuOpen(mobileOpenPath, pathname);
+  const [mobileMenuState, setMobileMenuState] = useState(() =>
+    createMobileMenuState(pathname),
+  );
+  const currentMobileMenuState = syncMobileMenuState(mobileMenuState, pathname);
+  if (currentMobileMenuState !== mobileMenuState) {
+    setMobileMenuState(currentMobileMenuState);
+  }
+  const mobileOpen = currentMobileMenuState.isOpen;
   const { isAuthenticated, user } = useAdminAuthState();
 
   const navItems = useMemo(() => {
@@ -104,7 +114,7 @@ export function Header() {
             <div className="flex md:hidden items-center gap-3">
               <button
                 onClick={() =>
-                  setMobileOpenPath((openPath) => toggleMobileMenuPath(openPath, pathname))
+                  setMobileMenuState((state) => toggleMobileMenuState(state, pathname))
                 }
                 className="text-foreground/70 hover:text-foreground transition-colors p-1"
                 aria-label="Toggle menu"

--- a/apps/admin/components/ui/badge.tsx
+++ b/apps/admin/components/ui/badge.tsx
@@ -1,1 +1,1 @@
-export { Badge, badgeVariants, type BadgeProps } from "@unforgit/ui/primitives";
+export { Badge } from "@unforgit/ui/primitives";

--- a/apps/admin/components/ui/button.tsx
+++ b/apps/admin/components/ui/button.tsx
@@ -1,1 +1,1 @@
-export { Button, buttonVariants, type ButtonProps } from "@unforgit/ui/primitives";
+export { Button } from "@unforgit/ui/primitives";

--- a/apps/admin/lib/auth-state.ts
+++ b/apps/admin/lib/auth-state.ts
@@ -1,0 +1,23 @@
+import type { User } from "./api";
+
+export interface AdminAuthState {
+  hydrated: boolean;
+  isAuthenticated: boolean;
+  user: User | null;
+}
+
+export function getAdminAuthState(
+  hydrated: boolean,
+  token: string | null,
+  userJson: string | null,
+): AdminAuthState {
+  if (!hydrated || !token) {
+    return { hydrated, isAuthenticated: false, user: null };
+  }
+
+  return {
+    hydrated: true,
+    isAuthenticated: true,
+    user: userJson ? (JSON.parse(userJson) as User) : null,
+  };
+}

--- a/apps/admin/lib/auth-store.ts
+++ b/apps/admin/lib/auth-store.ts
@@ -1,0 +1,38 @@
+import { useSyncExternalStore } from "react";
+import { getAdminAuthState, type AdminAuthState } from "./auth-state";
+
+const subscribeToStorage = (onStoreChange: () => void) => {
+  if (typeof window === "undefined") return () => {};
+
+  window.addEventListener("storage", onStoreChange);
+  return () => window.removeEventListener("storage", onStoreChange);
+};
+
+const subscribeToHydration = () => () => {};
+const getClientHydrationSnapshot = () => true;
+const getServerHydrationSnapshot = () => false;
+const getServerStorageSnapshot = () => null;
+const getTokenSnapshot = () =>
+  typeof window === "undefined" ? null : localStorage.getItem("admin_token");
+const getUserSnapshot = () =>
+  typeof window === "undefined" ? null : localStorage.getItem("user");
+
+export function useAdminAuthState(): AdminAuthState {
+  const hydrated = useSyncExternalStore(
+    subscribeToHydration,
+    getClientHydrationSnapshot,
+    getServerHydrationSnapshot,
+  );
+  const token = useSyncExternalStore(
+    subscribeToStorage,
+    getTokenSnapshot,
+    getServerStorageSnapshot,
+  );
+  const userJson = useSyncExternalStore(
+    subscribeToStorage,
+    getUserSnapshot,
+    getServerStorageSnapshot,
+  );
+
+  return getAdminAuthState(hydrated, token, userJson);
+}

--- a/apps/admin/src/__tests__/auth-store.test.ts
+++ b/apps/admin/src/__tests__/auth-store.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { getAdminAuthState } from "../../lib/auth-state";
+
+const storedUser = JSON.stringify({
+  id: "user-1",
+  githubId: 42,
+  githubLogin: "octocat",
+  name: "Octo Cat",
+  email: null,
+  avatarUrl: null,
+  isAdmin: true,
+});
+
+describe("admin auth state", () => {
+  it("stays unauthenticated until client storage has hydrated", () => {
+    expect(getAdminAuthState(false, "token", storedUser)).toEqual({
+      hydrated: false,
+      isAuthenticated: false,
+      user: null,
+    });
+  });
+
+  it("exposes the stored user after token hydration", () => {
+    expect(getAdminAuthState(true, "token", storedUser)).toEqual({
+      hydrated: true,
+      isAuthenticated: true,
+      user: expect.objectContaining({ githubLogin: "octocat", isAdmin: true }),
+    });
+  });
+
+  it("does not expose stale user data without a token", () => {
+    expect(getAdminAuthState(true, null, storedUser)).toEqual({
+      hydrated: true,
+      isAuthenticated: false,
+      user: null,
+    });
+  });
+});

--- a/apps/cli/src/__tests__/eslint-config.test.ts
+++ b/apps/cli/src/__tests__/eslint-config.test.ts
@@ -20,3 +20,58 @@ describe("repository ESLint discovery", () => {
     ).resolves.toBe(false);
   });
 });
+
+describe("canonical React lint annotations", () => {
+  const recurringWarningRules = new Set([
+    "@typescript-eslint/no-explicit-any",
+    "react-hooks/set-state-in-effect",
+    "react-refresh/only-export-components",
+  ]);
+
+  it("does not emit the recurring warning classes from product source", async () => {
+    const results = await eslint.lintFiles([
+      "apps/admin/**/*.{ts,tsx}",
+      "apps/web/**/*.{ts,tsx}",
+      "apps/website/**/*.{ts,tsx}",
+    ]);
+    const warnings = results.flatMap((result) =>
+      result.messages
+        .filter((message) => message.ruleId && recurringWarningRules.has(message.ruleId))
+        .map((message) => ({
+          file: path.relative(repoRoot, result.filePath),
+          line: message.line,
+          ruleId: message.ruleId,
+        })),
+    );
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("allows Next.js metadata exports next to app components", async () => {
+    const [result] = await eslint.lintText(
+      [
+        'import type { Metadata } from "next";',
+        'export const metadata: Metadata = { title: "Docs" };',
+        "export default function Layout() { return null; }",
+      ].join("\n"),
+      { filePath: "apps/website/app/test-layout.tsx" },
+    );
+
+    expect(result.messages.filter((message) => message.ruleId === "react-refresh/only-export-components"))
+      .toEqual([]);
+  });
+
+  it("keeps warning on arbitrary non-component exports from React modules", async () => {
+    const [result] = await eslint.lintText(
+      [
+        "export const helper = () => 42;",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+      { filePath: "apps/website/components/test-page.tsx" },
+    );
+
+    expect(result.messages.map((message) => message.ruleId)).toContain(
+      "react-refresh/only-export-components",
+    );
+  });
+});

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,7 +6,8 @@ import { Brain, ArrowRight, Sparkles, GitMerge, Network } from "lucide-react";
 import { StatsCards } from "@/components/stats-cards";
 import { ActivityHeatmap } from "@/components/activity-heatmap";
 import { MemoryTypeChart, DailyMemoriesChart, TopTagsChart, MemoryLifecycleChart } from "@/components/dashboard-charts";
-import { TimeframeSelector, type Timeframe, getTimeframeDays } from "@/components/timeframe-selector";
+import { TimeframeSelector } from "@/components/timeframe-selector";
+import { getTimeframeDays, type Timeframe } from "@/lib/timeframe";
 
 interface StoreStats {
   total: number;

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -5,7 +5,11 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Cloud, CloudUpload, Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { isMobileMenuOpen, toggleMobileMenuPath } from "@unforgit/ui/utils";
+import {
+  createMobileMenuState,
+  syncMobileMenuState,
+  toggleMobileMenuState,
+} from "@unforgit/ui/utils";
 import { useSyncContext } from "./sync-provider";
 
 const navItems = [
@@ -62,8 +66,14 @@ function SyncIndicator() {
 
 export function Header() {
   const pathname = usePathname();
-  const [mobileOpenPath, setMobileOpenPath] = useState<string | null>(null);
-  const mobileOpen = isMobileMenuOpen(mobileOpenPath, pathname);
+  const [mobileMenuState, setMobileMenuState] = useState(() =>
+    createMobileMenuState(pathname),
+  );
+  const currentMobileMenuState = syncMobileMenuState(mobileMenuState, pathname);
+  if (currentMobileMenuState !== mobileMenuState) {
+    setMobileMenuState(currentMobileMenuState);
+  }
+  const mobileOpen = currentMobileMenuState.isOpen;
 
   return (
     <>
@@ -109,7 +119,7 @@ export function Header() {
           <SyncIndicator />
           <button
             onClick={() =>
-              setMobileOpenPath((openPath) => toggleMobileMenuPath(openPath, pathname))
+              setMobileMenuState((state) => toggleMobileMenuState(state, pathname))
             }
             className="text-foreground/70 hover:text-foreground transition-colors p-1"
             aria-label="Toggle menu"

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Cloud, CloudUpload, Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { isMobileMenuOpen, toggleMobileMenuPath } from "@unforgit/ui/utils";
 import { useSyncContext } from "./sync-provider";
 
 const navItems = [
@@ -61,11 +62,8 @@ function SyncIndicator() {
 
 export function Header() {
   const pathname = usePathname();
-  const [mobileOpen, setMobileOpen] = useState(false);
-
-  useEffect(() => {
-    setMobileOpen(false);
-  }, [pathname]);
+  const [mobileOpenPath, setMobileOpenPath] = useState<string | null>(null);
+  const mobileOpen = isMobileMenuOpen(mobileOpenPath, pathname);
 
   return (
     <>
@@ -110,7 +108,9 @@ export function Header() {
         <div className="flex md:hidden items-center gap-3">
           <SyncIndicator />
           <button
-            onClick={() => setMobileOpen(!mobileOpen)}
+            onClick={() =>
+              setMobileOpenPath((openPath) => toggleMobileMenuPath(openPath, pathname))
+            }
             className="text-foreground/70 hover:text-foreground transition-colors p-1"
             aria-label="Toggle menu"
           >

--- a/apps/web/components/memory-detail-sheet.tsx
+++ b/apps/web/components/memory-detail-sheet.tsx
@@ -43,6 +43,10 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import {
+  createMemoryDetailState,
+  type MemoryDetailInitialState,
+} from "@/lib/memory-detail-state";
 
 interface MemoryDetail {
   id: string;
@@ -87,6 +91,11 @@ interface MemoryDetailSheetProps {
   onClose: () => void;
   onAction: () => void;
   onNavigate?: (id: string) => void;
+}
+
+interface MemoryDetailContentProps extends Omit<MemoryDetailSheetProps, "memoryId"> {
+  memoryId: string;
+  initialState: MemoryDetailInitialState;
 }
 
 const typeConfig: Record<string, { bg: string; text: string }> = {
@@ -241,26 +250,36 @@ function SourceRefItem({
   );
 }
 
-export function MemoryDetailSheet({
+export function MemoryDetailSheet(props: MemoryDetailSheetProps) {
+  const initialState = createMemoryDetailState(props.memoryId);
+  if (!initialState || !props.memoryId) return null;
+
+  return (
+    <MemoryDetailContent
+      key={initialState.key}
+      {...props}
+      memoryId={props.memoryId}
+      initialState={initialState}
+    />
+  );
+}
+
+function MemoryDetailContent({
   memoryId,
   onClose,
   onAction,
   onNavigate,
-}: MemoryDetailSheetProps) {
-  const [memory, setMemory] = useState<MemoryDetail | null>(null);
+  initialState,
+}: MemoryDetailContentProps) {
+  const [memory, setMemory] = useState<MemoryDetail | null>(initialState.memory);
   const [source, setSource] = useState<"local" | "remote">("local");
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(initialState.loading);
   const [copied, setCopied] = useState(false);
-  const [linkedMemories, setLinkedMemories] = useState<LinkedMemoryItem[]>([]);
+  const [linkedMemories, setLinkedMemories] = useState<LinkedMemoryItem[]>(
+    initialState.linkedMemories,
+  );
 
   useEffect(() => {
-    if (!memoryId) {
-      setMemory(null);
-      setLinkedMemories([]);
-      return;
-    }
-
-    setLoading(true);
     fetch(`/api/memories/${memoryId}`)
       .then((r) => {
         if (!r.ok) throw new Error("Not found");

--- a/apps/web/components/timeframe-selector.tsx
+++ b/apps/web/components/timeframe-selector.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-
-export type Timeframe = "all" | "1d" | "1w" | "1m" | "3m" | "6m" | "1y";
+import { TIMEFRAME_OPTIONS, type Timeframe } from "@/lib/timeframe";
 
 interface TimeframeSelectorProps {
   value: Timeframe;
@@ -10,15 +9,6 @@ interface TimeframeSelectorProps {
   className?: string;
 }
 
-const TIMEFRAME_OPTIONS: { value: Timeframe; label: string }[] = [
-  { value: "all", label: "All" },
-  { value: "1d", label: "1 Day" },
-  { value: "1w", label: "1 Week" },
-  { value: "1m", label: "1 Month" },
-  { value: "3m", label: "3 Months" },
-  { value: "6m", label: "6 Months" },
-  { value: "1y", label: "1 Year" },
-];
 
 export function TimeframeSelector({ value, onChange, className }: TimeframeSelectorProps) {
   return (
@@ -39,21 +29,4 @@ export function TimeframeSelector({ value, onChange, className }: TimeframeSelec
       ))}
     </div>
   );
-}
-
-export function getTimeframeLabel(timeframe: Timeframe): string {
-  const option = TIMEFRAME_OPTIONS.find((o) => o.value === timeframe);
-  return option?.label ?? "All";
-}
-
-export function getTimeframeDays(timeframe: Timeframe): number | null {
-  switch (timeframe) {
-    case "1d": return 1;
-    case "1w": return 7;
-    case "1m": return 30;
-    case "3m": return 90;
-    case "6m": return 180;
-    case "1y": return 365;
-    default: return null;
-  }
 }

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -1,1 +1,1 @@
-export { Badge, badgeVariants, type BadgeProps } from "@unforgit/ui/primitives";
+export { Badge } from "@unforgit/ui/primitives";

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,1 +1,1 @@
-export { Button, buttonVariants, type ButtonProps } from "@unforgit/ui/primitives";
+export { Button } from "@unforgit/ui/primitives";

--- a/apps/web/lib/memory-detail-state.ts
+++ b/apps/web/lib/memory-detail-state.ts
@@ -1,0 +1,19 @@
+export interface MemoryDetailInitialState {
+  key: string;
+  loading: boolean;
+  memory: null;
+  linkedMemories: [];
+}
+
+export function createMemoryDetailState(
+  memoryId: string | null,
+): MemoryDetailInitialState | null {
+  if (!memoryId) return null;
+
+  return {
+    key: memoryId,
+    loading: true,
+    memory: null,
+    linkedMemories: [],
+  };
+}

--- a/apps/web/lib/timeframe.ts
+++ b/apps/web/lib/timeframe.ts
@@ -1,0 +1,35 @@
+export type Timeframe = "all" | "1d" | "1w" | "1m" | "3m" | "6m" | "1y";
+
+export const TIMEFRAME_OPTIONS: { value: Timeframe; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "1d", label: "1 Day" },
+  { value: "1w", label: "1 Week" },
+  { value: "1m", label: "1 Month" },
+  { value: "3m", label: "3 Months" },
+  { value: "6m", label: "6 Months" },
+  { value: "1y", label: "1 Year" },
+];
+
+export function getTimeframeLabel(timeframe: Timeframe): string {
+  const option = TIMEFRAME_OPTIONS.find((candidate) => candidate.value === timeframe);
+  return option?.label ?? "All";
+}
+
+export function getTimeframeDays(timeframe: Timeframe): number | null {
+  switch (timeframe) {
+    case "1d":
+      return 1;
+    case "1w":
+      return 7;
+    case "1m":
+      return 30;
+    case "3m":
+      return 90;
+    case "6m":
+      return 180;
+    case "1y":
+      return 365;
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/__tests__/react-lint-behavior.test.ts
+++ b/apps/web/src/__tests__/react-lint-behavior.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createMemoryDetailState } from "../../lib/memory-detail-state";
+import {
+  getTimeframeDays,
+  getTimeframeLabel,
+} from "../../lib/timeframe";
+
+describe("memory detail selection state", () => {
+  it("does not retain detail state after the selection closes", () => {
+    expect(createMemoryDetailState(null)).toBeNull();
+  });
+
+  it("starts each selected memory with fresh loading state", () => {
+    expect(createMemoryDetailState("memory-2")).toEqual({
+      key: "memory-2",
+      loading: true,
+      memory: null,
+      linkedMemories: [],
+    });
+  });
+});
+
+describe("dashboard timeframe helpers", () => {
+  it("maps each bounded timeframe to its day count", () => {
+    expect(getTimeframeDays("1d")).toBe(1);
+    expect(getTimeframeDays("1w")).toBe(7);
+    expect(getTimeframeDays("1m")).toBe(30);
+    expect(getTimeframeDays("3m")).toBe(90);
+    expect(getTimeframeDays("6m")).toBe(180);
+    expect(getTimeframeDays("1y")).toBe(365);
+  });
+
+  it("keeps all-time unbounded and labels unknown values safely", () => {
+    expect(getTimeframeDays("all")).toBeNull();
+    expect(getTimeframeLabel("all")).toBe("All");
+  });
+});

--- a/apps/website/components/command-reference.tsx
+++ b/apps/website/components/command-reference.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { useHydrated } from "@/lib/use-hydrated";
 import { Terminal } from "./terminal";
 
 interface CommandOption {
@@ -28,11 +28,7 @@ export function CommandReference({
   options,
   example,
 }: CommandReferenceProps) {
-  const [isMounted, setIsMounted] = useState(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
+  const isMounted = useHydrated();
 
   const Wrapper = isMounted ? motion.div : "div";
   const wrapperProps = isMounted

--- a/apps/website/components/docs-sidebar.tsx
+++ b/apps/website/components/docs-sidebar.tsx
@@ -21,6 +21,7 @@ import {
   BookOpen,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { resolveDocsHash } from "@/lib/docs-navigation";
 import Link from "next/link";
 
 const mainSections = [
@@ -193,11 +194,18 @@ export function DocsSidebar() {
   }, [sections, defaultSection]);
 
   useEffect(() => {
-    const hash = window.location.hash.slice(1);
+    const sectionIds = sections.flatMap((section) => [
+      section.id,
+      ...("subsections" in section && section.subsections
+        ? section.subsections.map((subsection) => subsection.id)
+        : []),
+    ]);
+    const hash = resolveDocsHash(window.location.hash, sectionIds);
+    let activeSectionFrame: number | null = null;
     if (hash) {
       const el = document.getElementById(hash);
       if (el) {
-        setActiveSection(hash);
+        activeSectionFrame = window.requestAnimationFrame(() => setActiveSection(hash));
         isUserClickRef.current = true;
         const offset = 100;
         const top = el.getBoundingClientRect().top + window.pageYOffset - offset;
@@ -209,9 +217,15 @@ export function DocsSidebar() {
     }
 
     window.addEventListener("scroll", handleScroll, { passive: true });
-    handleScroll();
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, [handleScroll]);
+    const initialScrollFrame = window.requestAnimationFrame(handleScroll);
+    return () => {
+      window.cancelAnimationFrame(initialScrollFrame);
+      if (activeSectionFrame !== null) {
+        window.cancelAnimationFrame(activeSectionFrame);
+      }
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [handleScroll, sections]);
 
   const scrollToSection = useCallback((id: string) => {
     const element = document.getElementById(id);

--- a/apps/website/components/mcp-integrations.tsx
+++ b/apps/website/components/mcp-integrations.tsx
@@ -143,44 +143,52 @@ export function McpIntegrations() {
             const isExternal =
               ide.href.startsWith("cursor://") ||
               ide.href.startsWith("https://");
-            const Wrapper = isExternal ? "a" : Link;
-            const wrapperProps = isExternal
-              ? { href: ide.href, target: "_blank", rel: "noopener noreferrer" }
-              : { href: ide.href };
-
-            return (
-              <Wrapper key={ide.name} {...(wrapperProps as any)}>
-                <motion.div
-                  initial={{ opacity: 0, y: 10 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true }}
-                  transition={{ duration: 0.3, delay: 0.2 + i * 0.05 }}
-                  whileHover={{ y: -4, scale: 1.03 }}
-                  className="rounded-xl border border-dracula-current/40 bg-dracula-current/20 p-5 flex flex-col items-center gap-3 group hover:border-dracula-comment/60 hover:bg-dracula-current/30 hover:shadow-2xl hover:shadow-white/6 transition-all duration-300 cursor-pointer h-full relative"
-                >
-                  {ide.installLink && (
-                    <span className="absolute top-2 right-2 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-dracula-foreground/10 text-[10px] font-medium text-dracula-foreground/70">
-                      <Download className="w-2.5 h-2.5" />
-                      Install
-                    </span>
+            const card = (
+              <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.3, delay: 0.2 + i * 0.05 }}
+                whileHover={{ y: -4, scale: 1.03 }}
+                className="rounded-xl border border-dracula-current/40 bg-dracula-current/20 p-5 flex flex-col items-center gap-3 group hover:border-dracula-comment/60 hover:bg-dracula-current/30 hover:shadow-2xl hover:shadow-white/6 transition-all duration-300 cursor-pointer h-full relative"
+              >
+                {ide.installLink && (
+                  <span className="absolute top-2 right-2 flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-dracula-foreground/10 text-[10px] font-medium text-dracula-foreground/70">
+                    <Download className="w-2.5 h-2.5" />
+                    Install
+                  </span>
+                )}
+                <div className="w-10 h-10 flex items-center justify-center text-dracula-foreground/60 group-hover:text-dracula-foreground transition-colors">
+                  {Icon ? (
+                    <Icon className="w-8 h-8" />
+                  ) : (
+                    <Plug className="w-7 h-7" />
                   )}
-                  <div className="w-10 h-10 flex items-center justify-center text-dracula-foreground/60 group-hover:text-dracula-foreground transition-colors">
-                    {Icon ? (
-                      <Icon className="w-8 h-8" />
-                    ) : (
-                      <Plug className="w-7 h-7" />
-                    )}
-                  </div>
-                  <div className="text-center">
-                    <p className="font-medium text-sm text-dracula-foreground">
-                      {ide.name}
-                    </p>
-                    <p className="text-xs text-dracula-comment mt-0.5">
-                      {ide.note}
-                    </p>
-                  </div>
-                </motion.div>
-              </Wrapper>
+                </div>
+                <div className="text-center">
+                  <p className="font-medium text-sm text-dracula-foreground">
+                    {ide.name}
+                  </p>
+                  <p className="text-xs text-dracula-comment mt-0.5">
+                    {ide.note}
+                  </p>
+                </div>
+              </motion.div>
+            );
+
+            return isExternal ? (
+              <a
+                key={ide.name}
+                href={ide.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {card}
+              </a>
+            ) : (
+              <Link key={ide.name} href={ide.href}>
+                {card}
+              </Link>
             );
           })}
         </motion.div>

--- a/apps/website/components/terminal.tsx
+++ b/apps/website/components/terminal.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo } from "react";
 import { motion } from "framer-motion";
 import { Copy, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useHydrated } from "@/lib/use-hydrated";
 
 interface TerminalProps {
   code: string;
@@ -250,11 +251,7 @@ export function Terminal({
   language = "bash",
 }: TerminalProps) {
   const [copied, setCopied] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
+  const isMounted = useHydrated();
 
   const handleCopy = async () => {
     const cleanCode = code

--- a/apps/website/lib/docs-navigation.ts
+++ b/apps/website/lib/docs-navigation.ts
@@ -1,0 +1,7 @@
+export function resolveDocsHash(
+  hash: string,
+  sectionIds: readonly string[],
+): string | null {
+  const sectionId = hash.startsWith("#") ? hash.slice(1) : hash;
+  return sectionId && sectionIds.includes(sectionId) ? sectionId : null;
+}

--- a/apps/website/lib/hydration.ts
+++ b/apps/website/lib/hydration.ts
@@ -1,0 +1,7 @@
+export function getClientHydrationSnapshot(): boolean {
+  return true;
+}
+
+export function getServerHydrationSnapshot(): boolean {
+  return false;
+}

--- a/apps/website/lib/use-hydrated.ts
+++ b/apps/website/lib/use-hydrated.ts
@@ -1,0 +1,15 @@
+import { useSyncExternalStore } from "react";
+import {
+  getClientHydrationSnapshot,
+  getServerHydrationSnapshot,
+} from "./hydration";
+
+const subscribe = () => () => {};
+
+export function useHydrated(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    getClientHydrationSnapshot,
+    getServerHydrationSnapshot,
+  );
+}

--- a/apps/website/src/__tests__/react-lint-behavior.test.ts
+++ b/apps/website/src/__tests__/react-lint-behavior.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  getClientHydrationSnapshot,
+  getServerHydrationSnapshot,
+} from "../../lib/hydration";
+import { resolveDocsHash } from "../../lib/docs-navigation";
+
+describe("hydration snapshots", () => {
+  it("keeps the server render static until the client hydrates", () => {
+    expect(getServerHydrationSnapshot()).toBe(false);
+    expect(getClientHydrationSnapshot()).toBe(true);
+  });
+});
+
+describe("documentation hash navigation", () => {
+  const sectionIds = ["overview", "getting-started", "cli-core"];
+
+  it("uses a valid hash section on initial navigation", () => {
+    expect(resolveDocsHash("#cli-core", sectionIds)).toBe("cli-core");
+  });
+
+  it("ignores empty and unknown hash sections", () => {
+    expect(resolveDocsHash("", sectionIds)).toBeNull();
+    expect(resolveDocsHash("#missing", sectionIds)).toBeNull();
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,4 +69,22 @@ export default tseslint.config(
       "react-hooks/refs": "warn",
     },
   },
+  {
+    files: ["apps/{admin,web,website}/app/**/*.{ts,tsx}"],
+    rules: {
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true, allowExportNames: ["metadata"] },
+      ],
+    },
+  },
+  {
+    files: ["apps/web/components/sync-provider.tsx"],
+    rules: {
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true, allowExportNames: ["useSyncContext"] },
+      ],
+    },
+  },
 );

--- a/packages/ui/src/__tests__/mobile-navigation.test.ts
+++ b/packages/ui/src/__tests__/mobile-navigation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  isMobileMenuOpen,
+  toggleMobileMenuPath,
+} from "../utils/mobile-navigation";
+
+describe("mobile navigation state", () => {
+  it("closes an open menu when navigation changes the pathname", () => {
+    expect(isMobileMenuOpen("/memories", "/settings")).toBe(false);
+  });
+
+  it("keeps an open menu visible while the pathname is unchanged", () => {
+    expect(isMobileMenuOpen("/memories", "/memories")).toBe(true);
+  });
+
+  it("toggles the menu for the current pathname", () => {
+    expect(toggleMobileMenuPath(null, "/memories")).toBe("/memories");
+    expect(toggleMobileMenuPath("/memories", "/memories")).toBeNull();
+  });
+});

--- a/packages/ui/src/__tests__/mobile-navigation.test.ts
+++ b/packages/ui/src/__tests__/mobile-navigation.test.ts
@@ -1,20 +1,28 @@
 import { describe, expect, it } from "vitest";
 import {
-  isMobileMenuOpen,
-  toggleMobileMenuPath,
+  createMobileMenuState,
+  syncMobileMenuState,
+  toggleMobileMenuState,
 } from "../utils/mobile-navigation";
 
 describe("mobile navigation state", () => {
-  it("closes an open menu when navigation changes the pathname", () => {
-    expect(isMobileMenuOpen("/memories", "/settings")).toBe(false);
-  });
-
-  it("keeps an open menu visible while the pathname is unchanged", () => {
-    expect(isMobileMenuOpen("/memories", "/memories")).toBe(true);
-  });
-
   it("toggles the menu for the current pathname", () => {
-    expect(toggleMobileMenuPath(null, "/memories")).toBe("/memories");
-    expect(toggleMobileMenuPath("/memories", "/memories")).toBeNull();
+    const closed = createMobileMenuState("/memories");
+    const open = toggleMobileMenuState(closed, "/memories");
+
+    expect(open).toEqual({ pathname: "/memories", isOpen: true });
+    expect(toggleMobileMenuState(open, "/memories")).toEqual(closed);
+  });
+
+  it("stays closed after navigating away and returning", () => {
+    let state = toggleMobileMenuState(
+      createMobileMenuState("/memories"),
+      "/memories",
+    );
+
+    state = syncMobileMenuState(state, "/settings");
+    state = syncMobileMenuState(state, "/memories");
+
+    expect(state).toEqual({ pathname: "/memories", isOpen: false });
   });
 });

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,3 +1,8 @@
 export { cn } from "./cn";
 export { formatRelativeTime, formatDate, truncateText } from "./format";
-export { isMobileMenuOpen, toggleMobileMenuPath } from "./mobile-navigation";
+export {
+  createMobileMenuState,
+  syncMobileMenuState,
+  toggleMobileMenuState,
+  type MobileMenuState,
+} from "./mobile-navigation";

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { cn } from "./cn";
 export { formatRelativeTime, formatDate, truncateText } from "./format";
+export { isMobileMenuOpen, toggleMobileMenuPath } from "./mobile-navigation";

--- a/packages/ui/src/utils/mobile-navigation.ts
+++ b/packages/ui/src/utils/mobile-navigation.ts
@@ -1,13 +1,23 @@
-export function isMobileMenuOpen(
-  openedPath: string | null,
-  currentPath: string,
-): boolean {
-  return openedPath === currentPath;
+export interface MobileMenuState {
+  pathname: string;
+  isOpen: boolean;
 }
 
-export function toggleMobileMenuPath(
-  openedPath: string | null,
+export function createMobileMenuState(pathname: string): MobileMenuState {
+  return { pathname, isOpen: false };
+}
+
+export function syncMobileMenuState(
+  state: MobileMenuState,
   currentPath: string,
-): string | null {
-  return isMobileMenuOpen(openedPath, currentPath) ? null : currentPath;
+): MobileMenuState {
+  return state.pathname === currentPath ? state : createMobileMenuState(currentPath);
+}
+
+export function toggleMobileMenuState(
+  state: MobileMenuState,
+  currentPath: string,
+): MobileMenuState {
+  const currentState = syncMobileMenuState(state, currentPath);
+  return { ...currentState, isOpen: !currentState.isOpen };
 }

--- a/packages/ui/src/utils/mobile-navigation.ts
+++ b/packages/ui/src/utils/mobile-navigation.ts
@@ -1,0 +1,13 @@
+export function isMobileMenuOpen(
+  openedPath: string | null,
+  currentPath: string,
+): boolean {
+  return openedPath === currentPath;
+}
+
+export function toggleMobileMenuPath(
+  openedPath: string | null,
+  currentPath: string,
+): string | null {
+  return isMobileMenuOpen(openedPath, currentPath) ? null : currentPath;
+}


### PR DESCRIPTION
## Summary
- remove all 21 recurring React and TypeScript lint annotations from canonical product source
- derive auth and mobile navigation state without synchronous effect updates
- reset memory-detail state by selection key and preserve SSR-safe website hydration
- keep fast-refresh exceptions narrowly scoped to Next.js metadata and the sync hook

## Warning counts
- before: 21 total (9 `react-hooks/set-state-in-effect`, 11 `react-refresh/only-export-components`, 1 `@typescript-eslint/no-explicit-any`)
- after: 0 targeted warnings; 0 total ESLint warnings

## Verification
- `pnpm lint`
- `pnpm test` (60 files, 315 tests)
- `pnpm build`
- `docker compose up -d --build` built API, admin, and website images; isolated worktree startup could not bind the canonical PostgreSQL port, and the newly created containers/network/empty volume were removed

Related to #46