### PR TITLE
fix(security): enforce admin consolidation scope

### DIFF
--- a/apps/api/src/__tests__/admin-auth.test.ts
+++ b/apps/api/src/__tests__/admin-auth.test.ts
@@ -297,4 +297,36 @@ describe("admin auth", () => {
     await app.close();
     delete process.env.OPENAI_API_KEY;
   });
+
+  it("rejects cross-repository sources before manual consolidation", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    process.env.OPENAI_API_KEY = "sk-test";
+    const store = buildStore();
+    store.getById
+      .mockResolvedValueOnce({
+        id: "foreign-memory",
+        orgId: "other-org",
+        repoId: "other-repo",
+        tags: [],
+      })
+      .mockResolvedValueOnce(null);
+    const token = await signAdminToken();
+    const app = await buildAdminApp(store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/admin/repos/org-id/repo-id/consolidation/execute",
+      headers: { authorization: `Bearer ${token}` },
+      payload: { sourceIds: ["foreign-memory", "own-memory"] },
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({
+      error: "Memory not found: foreign-memory",
+    });
+    expect(store.getById).toHaveBeenCalledOnce();
+    expect(store.getById).toHaveBeenCalledWith("foreign-memory");
+
+    await app.close();
+  });
 });

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -683,7 +683,11 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
       const memories = [];
       for (const id of sourceIds) {
         const memory = await store.getById(id);
-        if (!memory) {
+        if (
+          !memory ||
+          memory.orgId.toLowerCase() !== orgId.toLowerCase() ||
+          memory.repoId.toLowerCase() !== repoId.toLowerCase()
+        ) {
           return reply.status(404).send({ error: `Memory not found: ${id}` });
         }
         memories.push(memory);


### PR DESCRIPTION
## Summary
- reject manual admin consolidation sources whose stored organization/repository does not match the route scope
- return the same fail-closed 404 behavior as the non-admin consolidation route
- add a regression test proving validation stops before a second lookup or any consolidation work

## TDD
- RED: focused test returned `Memory not found: own-memory`, proving the foreign first source was accepted
- GREEN: focused regression test passes

## Verification
- `pnpm test` (Node 24.15.0): 63 files, 348 tests passed
- tracked-source ESLint: 0 errors (3 ignored generated-file warnings)
- `pnpm build`: passed
- `pnpm smoke:cli`: passed
- `pnpm smoke:packed-cli`: passed on Linux x64, Node 24.15.0
- `pnpm audit --audit-level high`: no known vulnerabilities
- `pnpm audit --prod --audit-level high`: no known vulnerabilities
- `docker compose down && docker compose up -d --build`: passed; API health, admin, and website verified

The unscoped local `pnpm lint` also sees unrelated untracked `.worktrees/` and `plugins/hermes-webui/` content; the tracked-source gate is clean and clean-checkout CI remains authoritative.