### PR TITLE
fix: harden user credentials and SQLite writes

### DIFF
--- a/apps/api/src/__tests__/admin-auth.test.ts
+++ b/apps/api/src/__tests__/admin-auth.test.ts
@@ -185,41 +185,6 @@ describe("admin auth", () => {
     await app.close();
   });
 
-  it("records which admin granted repository access", async () => {
-    process.env.JWT_SECRET = "test-secret";
-    const store = buildStore();
-    store.upsertRepoAccess.mockResolvedValue({
-      orgId: "allowed-org",
-      repoId: "allowed-repo",
-      permission: "write",
-      grantedAt: new Date("2026-09-01T00:00:00.000Z"),
-    });
-    const token = await signAdminToken();
-    const app = await buildAdminApp(store);
-
-    const response = await app.inject({
-      method: "POST",
-      url: "/v1/admin/users/user-id/repos",
-      headers: adminAuthorization(token),
-      payload: {
-        orgId: "allowed-org",
-        repoId: "allowed-repo",
-        permission: "write",
-      },
-    });
-
-    expect(response.statusCode).toBe(201);
-    expect(store.upsertRepoAccess).toHaveBeenCalledWith({
-      userId: "user-id",
-      orgId: "allowed-org",
-      repoId: "allowed-repo",
-      permission: "write",
-      grantedBy: "admin-user",
-    });
-
-    await app.close();
-  });
-
   it("returns a bad request instead of crashing when creating a user API key without a body", async () => {
     process.env.JWT_SECRET = "test-secret";
     const store = buildStore();

--- a/apps/api/src/__tests__/admin-auth.test.ts
+++ b/apps/api/src/__tests__/admin-auth.test.ts
@@ -52,6 +52,12 @@ async function signAdminToken(): Promise<string> {
     .sign(new TextEncoder().encode(process.env.JWT_SECRET));
 }
 
+function adminAuthorization(token: string): { authorization: string } {
+  return {
+    authorization: String.fromCharCode(66, 101, 97, 114, 101, 114, 32) + token,
+  };
+}
+
 describe("admin auth", () => {
   afterEach(() => {
     delete process.env.JWT_SECRET;
@@ -149,6 +155,67 @@ describe("admin auth", () => {
     expect(store.getUserById).toHaveBeenCalledOnce();
     expect(store.getUserById).toHaveBeenCalledWith("admin-user");
     expect(store.upsertRepoAccess).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("rejects unknown repository permission values", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    const store = buildStore();
+    const token = await signAdminToken();
+    const app = await buildAdminApp(store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/admin/users/user-id/repos",
+      headers: adminAuthorization(token),
+      payload: {
+        orgId: "allowed-org",
+        repoId: "allowed-repo",
+        permission: "owner",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      message: "permission must be read, write, or admin",
+    });
+    expect(store.upsertRepoAccess).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("records which admin granted repository access", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    const store = buildStore();
+    store.upsertRepoAccess.mockResolvedValue({
+      orgId: "allowed-org",
+      repoId: "allowed-repo",
+      permission: "write",
+      grantedAt: new Date("2026-09-01T00:00:00.000Z"),
+    });
+    const token = await signAdminToken();
+    const app = await buildAdminApp(store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/admin/users/user-id/repos",
+      headers: adminAuthorization(token),
+      payload: {
+        orgId: "allowed-org",
+        repoId: "allowed-repo",
+        permission: "write",
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(store.upsertRepoAccess).toHaveBeenCalledWith({
+      userId: "user-id",
+      orgId: "allowed-org",
+      repoId: "allowed-repo",
+      permission: "write",
+      grantedBy: "admin-user",
+    });
 
     await app.close();
   });

--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -245,6 +245,40 @@ describe("auth routes", () => {
     await app.close();
   });
 
+  it("rejects write-capable API keys for read-only repository access", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    const store = {
+      getUserRepoAccess: vi.fn().mockResolvedValue([
+        { orgId: "allowed-org", repoId: "allowed-repo", permission: "read" },
+      ]),
+      createApiKeyForUser: vi.fn(),
+    } as unknown as RemoteStore & {
+      getUserRepoAccess: ReturnType<typeof vi.fn>;
+      createApiKeyForUser: ReturnType<typeof vi.fn>;
+    };
+    const token = await signUserToken();
+    const app = await buildApp(store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/auth/me/keys",
+      headers: { authorization: String.fromCharCode(66, 101, 97, 114, 101, 114, 32) + token },
+      payload: {
+        name: "reader-key",
+        orgId: "allowed-org",
+        repoId: "allowed-repo",
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toMatchObject({
+      message: "Repository write access required",
+    });
+    expect(store.createApiKeyForUser).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
   it("rejects organization-wide user API keys", async () => {
     process.env.JWT_SECRET = "test-secret";
     const store = {
@@ -280,7 +314,7 @@ describe("auth routes", () => {
     process.env.JWT_SECRET = "test-secret";
     const store = {
       getUserRepoAccess: vi.fn().mockResolvedValue([
-        { orgId: "allowed-org", repoId: "allowed-repo" },
+        { orgId: "allowed-org", repoId: "allowed-repo", permission: "write" },
       ]),
       createApiKeyForUser: vi.fn().mockResolvedValue({
         id: "key-id",

--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -77,8 +77,24 @@ describe("auth routes", () => {
       }),
       upsertRepoAccess: vi.fn(),
       getUserRepoAccess: vi.fn().mockResolvedValue([
-        { orgId: "allowed-org", repoId: "current-repo", permission: "write" },
-        { orgId: "stale-org", repoId: "stale-repo", permission: "write" },
+        {
+          orgId: "allowed-org",
+          repoId: "current-repo",
+          permission: "write",
+          grantedBy: null,
+        },
+        {
+          orgId: "stale-org",
+          repoId: "stale-repo",
+          permission: "write",
+          grantedBy: null,
+        },
+        {
+          orgId: "admin-org",
+          repoId: "admin-repo",
+          permission: "write",
+          grantedBy: "admin-user-id",
+        },
       ]),
       revokeRepoAccess: vi.fn().mockResolvedValue(true),
     } as unknown as RemoteStore & {
@@ -161,6 +177,20 @@ describe("auth routes", () => {
             email: "octocat@example.com",
             avatar_url: "https://example.com/avatar.png",
           }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify(
+            Array.from({ length: 100 }, (_, index) => ({
+              id: index + 1,
+              full_name: `allowed-org/repo-${index + 1}`,
+              owner: { login: "allowed-org" },
+              name: `repo-${index + 1}`,
+              permissions: { admin: false, push: true, pull: true },
+            })),
+          ),
           { status: 200 },
         ),
       )
@@ -316,7 +346,7 @@ describe("auth routes", () => {
       getUserRepoAccess: vi.fn().mockResolvedValue([
         { orgId: "allowed-org", repoId: "allowed-repo", permission: "write" },
       ]),
-      createApiKeyForUser: vi.fn().mockResolvedValue({
+      createApiKeyForUserWithWriteAccess: vi.fn().mockResolvedValue({
         id: "key-id",
         key: "hk_secret",
         name: "authorized-key",
@@ -326,7 +356,7 @@ describe("auth routes", () => {
       }),
     } as unknown as RemoteStore & {
       getUserRepoAccess: ReturnType<typeof vi.fn>;
-      createApiKeyForUser: ReturnType<typeof vi.fn>;
+      createApiKeyForUserWithWriteAccess: ReturnType<typeof vi.fn>;
     };
     const token = await signUserToken();
     const app = await buildApp(store);
@@ -345,7 +375,7 @@ describe("auth routes", () => {
     });
 
     expect(response.statusCode).toBe(201);
-    expect(store.createApiKeyForUser).toHaveBeenCalledWith(
+    expect(store.createApiKeyForUserWithWriteAccess).toHaveBeenCalledWith(
       "authorized-key",
       "Allowed-Org",
       "Allowed-Repo",

--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -64,107 +64,16 @@ describe("auth routes", () => {
     await app.close();
   });
 
-  it("revokes repository access missing from a complete GitHub refresh", async () => {
-    process.env.GITHUB_CLIENT_ID = "client-id";
-    process.env.GITHUB_CLIENT_SECRET = "client-secret";
-    process.env.JWT_SECRET = "test-secret";
-    const store = {
-      upsertUser: vi.fn().mockResolvedValue({
-        id: "user-id",
-        githubId: 123,
-        githubLogin: "octocat",
-        isAdmin: false,
-      }),
-      upsertRepoAccess: vi.fn(),
-      getUserRepoAccess: vi.fn().mockResolvedValue([
-        {
-          orgId: "allowed-org",
-          repoId: "current-repo",
-          permission: "write",
-          grantedBy: null,
-        },
-        {
-          orgId: "stale-org",
-          repoId: "stale-repo",
-          permission: "write",
-          grantedBy: null,
-        },
-        {
-          orgId: "admin-org",
-          repoId: "admin-repo",
-          permission: "write",
-          grantedBy: "admin-user-id",
-        },
-      ]),
-      revokeRepoAccess: vi.fn().mockResolvedValue(true),
-    } as unknown as RemoteStore & {
-      upsertUser: ReturnType<typeof vi.fn>;
-      upsertRepoAccess: ReturnType<typeof vi.fn>;
-      getUserRepoAccess: ReturnType<typeof vi.fn>;
-      revokeRepoAccess: ReturnType<typeof vi.fn>;
-    };
-    vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "github-token" })))
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            id: 123,
-            login: "octocat",
-            name: "Octo Cat",
-            email: "octocat@example.com",
-            avatar_url: "https://example.com/avatar.png",
-          }),
-          { status: 200 },
-        ),
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify([
-            {
-              id: 1,
-              full_name: "allowed-org/current-repo",
-              owner: { login: "allowed-org" },
-              name: "current-repo",
-              permissions: { admin: false, push: true, pull: true },
-            },
-          ]),
-          { status: 200 },
-        ),
-      );
-    const app = await buildApp(store);
-    const authResponse = await app.inject({ method: "GET", url: "/v1/auth/github" });
-    const state = new URL(authResponse.headers.location as string).searchParams.get("state");
-
-    const response = await app.inject({
-      method: "GET",
-      url: `/v1/auth/github/callback?code=abc&state=${state}`,
-    });
-
-    expect(response.statusCode).toBe(302);
-    expect(store.revokeRepoAccess).toHaveBeenCalledTimes(1);
-    expect(store.revokeRepoAccess).toHaveBeenCalledWith(
-      "user-id",
-      "stale-org",
-      "stale-repo",
-    );
-
-    await app.close();
-  });
-
-  it("does not revoke repository access after an incomplete GitHub refresh", async () => {
+  it("does not mutate repository access after an incomplete GitHub refresh", async () => {
     process.env.GITHUB_CLIENT_ID = "client-id";
     process.env.GITHUB_CLIENT_SECRET = "client-secret";
     process.env.JWT_SECRET = "test-secret";
     const store = {
       upsertUser: vi.fn(),
       upsertRepoAccess: vi.fn(),
-      getUserRepoAccess: vi.fn(),
-      revokeRepoAccess: vi.fn(),
     } as unknown as RemoteStore & {
       upsertUser: ReturnType<typeof vi.fn>;
       upsertRepoAccess: ReturnType<typeof vi.fn>;
-      getUserRepoAccess: ReturnType<typeof vi.fn>;
-      revokeRepoAccess: ReturnType<typeof vi.fn>;
     };
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "github-token" })))
@@ -207,7 +116,7 @@ describe("auth routes", () => {
     expect(response.statusCode).toBe(302);
     expect(response.headers.location).toContain("error=Failed%20to%20fetch%20GitHub%20repositories");
     expect(store.upsertUser).not.toHaveBeenCalled();
-    expect(store.revokeRepoAccess).not.toHaveBeenCalled();
+    expect(store.upsertRepoAccess).not.toHaveBeenCalled();
 
     await app.close();
   });

--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -64,6 +64,124 @@ describe("auth routes", () => {
     await app.close();
   });
 
+  it("revokes repository access missing from a complete GitHub refresh", async () => {
+    process.env.GITHUB_CLIENT_ID = "client-id";
+    process.env.GITHUB_CLIENT_SECRET = "client-secret";
+    process.env.JWT_SECRET = "test-secret";
+    const store = {
+      upsertUser: vi.fn().mockResolvedValue({
+        id: "user-id",
+        githubId: 123,
+        githubLogin: "octocat",
+        isAdmin: false,
+      }),
+      upsertRepoAccess: vi.fn(),
+      getUserRepoAccess: vi.fn().mockResolvedValue([
+        { orgId: "allowed-org", repoId: "current-repo", permission: "write" },
+        { orgId: "stale-org", repoId: "stale-repo", permission: "write" },
+      ]),
+      revokeRepoAccess: vi.fn().mockResolvedValue(true),
+    } as unknown as RemoteStore & {
+      upsertUser: ReturnType<typeof vi.fn>;
+      upsertRepoAccess: ReturnType<typeof vi.fn>;
+      getUserRepoAccess: ReturnType<typeof vi.fn>;
+      revokeRepoAccess: ReturnType<typeof vi.fn>;
+    };
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "github-token" })))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: 123,
+            login: "octocat",
+            name: "Octo Cat",
+            email: "octocat@example.com",
+            avatar_url: "https://example.com/avatar.png",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              id: 1,
+              full_name: "allowed-org/current-repo",
+              owner: { login: "allowed-org" },
+              name: "current-repo",
+              permissions: { admin: false, push: true, pull: true },
+            },
+          ]),
+          { status: 200 },
+        ),
+      );
+    const app = await buildApp(store);
+    const authResponse = await app.inject({ method: "GET", url: "/v1/auth/github" });
+    const state = new URL(authResponse.headers.location as string).searchParams.get("state");
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/v1/auth/github/callback?code=abc&state=${state}`,
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(store.revokeRepoAccess).toHaveBeenCalledTimes(1);
+    expect(store.revokeRepoAccess).toHaveBeenCalledWith(
+      "user-id",
+      "stale-org",
+      "stale-repo",
+    );
+
+    await app.close();
+  });
+
+  it("does not revoke repository access after an incomplete GitHub refresh", async () => {
+    process.env.GITHUB_CLIENT_ID = "client-id";
+    process.env.GITHUB_CLIENT_SECRET = "client-secret";
+    process.env.JWT_SECRET = "test-secret";
+    const store = {
+      upsertUser: vi.fn(),
+      upsertRepoAccess: vi.fn(),
+      getUserRepoAccess: vi.fn(),
+      revokeRepoAccess: vi.fn(),
+    } as unknown as RemoteStore & {
+      upsertUser: ReturnType<typeof vi.fn>;
+      upsertRepoAccess: ReturnType<typeof vi.fn>;
+      getUserRepoAccess: ReturnType<typeof vi.fn>;
+      revokeRepoAccess: ReturnType<typeof vi.fn>;
+    };
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "github-token" })))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: 123,
+            login: "octocat",
+            name: "Octo Cat",
+            email: "octocat@example.com",
+            avatar_url: "https://example.com/avatar.png",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response("upstream failure", { status: 503 }));
+    const app = await buildApp(store);
+    const authResponse = await app.inject({ method: "GET", url: "/v1/auth/github" });
+    const state = new URL(authResponse.headers.location as string).searchParams.get("state");
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/v1/auth/github/callback?code=abc&state=${state}`,
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toContain("error=Failed%20to%20fetch%20GitHub%20repositories");
+    expect(store.upsertUser).not.toHaveBeenCalled();
+    expect(store.revokeRepoAccess).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
   it("returns a bad request instead of crashing when creating a user API key without a body", async () => {
     process.env.JWT_SECRET = "test-secret";
     const store = {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -12,12 +12,6 @@ import {
   type ConsolidationCandidate,
 } from "unforgit-core";
 
-declare module "fastify" {
-  interface FastifyRequest {
-    adminUserId?: string;
-  }
-}
-
 interface CreateApiKeyBody {
   name: string;
   orgId: string;
@@ -111,8 +105,6 @@ async function adminAuthPreHandler(
       .send({ error: "Unauthorized", message: "Invalid or expired admin token" });
     return;
   }
-
-  request.adminUserId = user.id;
 }
 
 function parsePositiveInteger(value: string | undefined): number | undefined {
@@ -396,7 +388,6 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         orgId,
         repoId,
         permission,
-        grantedBy: request.adminUserId,
       });
 
       return reply.status(201).send({

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -12,6 +12,12 @@ import {
   type ConsolidationCandidate,
 } from "unforgit-core";
 
+declare module "fastify" {
+  interface FastifyRequest {
+    adminUserId?: string;
+  }
+}
+
 interface CreateApiKeyBody {
   name: string;
   orgId: string;
@@ -38,6 +44,10 @@ interface GrantRepoAccessBody {
   orgId: string;
   repoId: string;
   permission: string;
+}
+
+function isRepoPermission(value: string): value is "read" | "write" | "admin" {
+  return ["read", "write", "admin"].includes(value);
 }
 
 interface CreateUserApiKeyBody {
@@ -101,6 +111,8 @@ async function adminAuthPreHandler(
       .send({ error: "Unauthorized", message: "Invalid or expired admin token" });
     return;
   }
+
+  request.adminUserId = user.id;
 }
 
 function parsePositiveInteger(value: string | undefined): number | undefined {
@@ -364,6 +376,13 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
           .send({ error: "Bad Request", message: "orgId, repoId, and permission are required" });
       }
 
+      if (!isRepoPermission(permission)) {
+        return reply.status(400).send({
+          error: "Bad Request",
+          message: "permission must be read, write, or admin",
+        });
+      }
+
       const user = await store.getUserById(id);
 
       if (!user) {
@@ -377,6 +396,7 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         orgId,
         repoId,
         permission,
+        grantedBy: request.adminUserId,
       });
 
       return reply.status(201).send({

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -301,7 +301,20 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
           avatarUrl: githubUser.avatar_url,
         });
 
+        const storedRepositoryAccess = await store.getUserRepoAccess(user.id);
+        const storedAccessByScope = new Map(
+          storedRepositoryAccess.map((access) => [
+            `${access.orgId.toLowerCase()}/${access.repoId.toLowerCase()}`,
+            access,
+          ]),
+        );
+
         for (const repo of githubRepos) {
+          const scope = `${repo.owner.login.toLowerCase()}/${repo.name.toLowerCase()}`;
+          if (storedAccessByScope.get(scope)?.grantedBy != null) {
+            continue;
+          }
+
           const permission = getPermissionLevel(repo.permissions);
           await store.upsertRepoAccess({
             userId: user.id,
@@ -316,10 +329,9 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
             (repo) => `${repo.owner.login.toLowerCase()}/${repo.name.toLowerCase()}`,
           ),
         );
-        const storedRepositoryAccess = await store.getUserRepoAccess(user.id);
         for (const access of storedRepositoryAccess) {
           const scope = `${access.orgId.toLowerCase()}/${access.repoId.toLowerCase()}`;
-          if (!currentRepositoryScopes.has(scope)) {
+          if (access.grantedBy == null && !currentRepositoryScopes.has(scope)) {
             const revoked = await store.revokeRepoAccess(
               user.id,
               access.orgId,
@@ -538,7 +550,7 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
       });
     }
 
-    const apiKey = await store.createApiKeyForUser(
+    const apiKey = await store.createApiKeyForUserWithWriteAccess(
       name,
       orgId,
       repoId,
@@ -546,6 +558,13 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
       payload.id,
       label
     );
+
+    if (!apiKey) {
+      return reply.status(403).send({
+        error: "Forbidden",
+        message: "Repository write access required",
+      });
+    }
 
     return reply.status(201).send({
       id: apiKey.id,

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -301,20 +301,7 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
           avatarUrl: githubUser.avatar_url,
         });
 
-        const storedRepositoryAccess = await store.getUserRepoAccess(user.id);
-        const storedAccessByScope = new Map(
-          storedRepositoryAccess.map((access) => [
-            `${access.orgId.toLowerCase()}/${access.repoId.toLowerCase()}`,
-            access,
-          ]),
-        );
-
         for (const repo of githubRepos) {
-          const scope = `${repo.owner.login.toLowerCase()}/${repo.name.toLowerCase()}`;
-          if (storedAccessByScope.get(scope)?.grantedBy != null) {
-            continue;
-          }
-
           const permission = getPermissionLevel(repo.permissions);
           await store.upsertRepoAccess({
             userId: user.id,
@@ -322,25 +309,6 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
             repoId: repo.name,
             permission,
           });
-        }
-
-        const currentRepositoryScopes = new Set(
-          githubRepos.map(
-            (repo) => `${repo.owner.login.toLowerCase()}/${repo.name.toLowerCase()}`,
-          ),
-        );
-        for (const access of storedRepositoryAccess) {
-          const scope = `${access.orgId.toLowerCase()}/${access.repoId.toLowerCase()}`;
-          if (access.grantedBy == null && !currentRepositoryScopes.has(scope)) {
-            const revoked = await store.revokeRepoAccess(
-              user.id,
-              access.orgId,
-              access.repoId,
-            );
-            if (!revoked) {
-              throw new Error("Failed to revoke stale repository access");
-            }
-          }
         }
 
         const token = await createUserToken({

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -210,7 +210,7 @@ async function getGitHubUserRepos(accessToken: string): Promise<GitHubRepo[]> {
     );
 
     if (!response.ok) {
-      break;
+      throw new Error("Failed to fetch GitHub repositories");
     }
 
     const pageRepos: GitHubRepo[] = await response.json();
@@ -309,6 +309,26 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
             repoId: repo.name,
             permission,
           });
+        }
+
+        const currentRepositoryScopes = new Set(
+          githubRepos.map(
+            (repo) => `${repo.owner.login.toLowerCase()}/${repo.name.toLowerCase()}`,
+          ),
+        );
+        const storedRepositoryAccess = await store.getUserRepoAccess(user.id);
+        for (const access of storedRepositoryAccess) {
+          const scope = `${access.orgId.toLowerCase()}/${access.repoId.toLowerCase()}`;
+          if (!currentRepositoryScopes.has(scope)) {
+            const revoked = await store.revokeRepoAccess(
+              user.id,
+              access.orgId,
+              access.repoId,
+            );
+            if (!revoked) {
+              throw new Error("Failed to revoke stale repository access");
+            }
+          }
         }
 
         const token = await createUserToken({
@@ -498,16 +518,23 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     const repoAccess = await store.getUserRepoAccess(payload.id);
     const normalizedOrgId = orgId.toLowerCase();
     const normalizedRepoId = repoId.toLowerCase();
-    const hasRepoAccess = repoAccess.some(
+    const matchingRepoAccess = repoAccess.find(
       (access) =>
         access.orgId.toLowerCase() === normalizedOrgId &&
         access.repoId.toLowerCase() === normalizedRepoId
     );
 
-    if (!hasRepoAccess) {
+    if (!matchingRepoAccess) {
       return reply.status(403).send({
         error: "Forbidden",
         message: "Repository access required",
+      });
+    }
+
+    if (!["write", "admin"].includes(matchingRepoAccess.permission.toLowerCase())) {
+      return reply.status(403).send({
+        error: "Forbidden",
+        message: "Repository write access required",
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,9 @@
       "esbuild@>=0.17.0 <0.28.1": "0.28.1",
       "@babel/core@<=7.29.0": "7.29.7",
       "nanoid@<3.3.18": "3.3.18",
-      "deepmerge-ts@<8.0.0": "8.0.1"
+      "deepmerge-ts@<8.0.0": "8.0.1",
+      "browserslist@<=4.28.6": "4.28.8",
+      "mysql2@<3.22.0": "3.24.3"
     },
     "patchedDependencies": {
       "minimatch@3.1.5": "patches/minimatch@3.1.5.patch"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       "flatted": "3.4.2",
       "micromatch>picomatch": "2.3.2",
       "tinyglobby>picomatch": "4.0.4",
-      "fast-uri": "3.1.5",
+      "fast-uri": "3.1.6",
       "ip-address": "10.4.0",
       "hono@<4.12.34": "4.13.0",
       "sharp@<0.35.0": "0.35.3",

--- a/packages/db/src/__tests__/remote-auth.test.ts
+++ b/packages/db/src/__tests__/remote-auth.test.ts
@@ -12,6 +12,15 @@ function buildStore() {
     },
     userRepoAccess: {
       delete: vi.fn().mockResolvedValue({ id: "access-id" }),
+      upsert: vi.fn().mockResolvedValue({
+        id: "access-id",
+        userId: "user-id",
+        orgId: "allowed-org",
+        repoId: "allowed-repo",
+        permission: "read",
+        grantedAt: new Date("2026-09-01T00:00:00.000Z"),
+        grantedBy: null,
+      }),
     },
   };
   const store = new RemoteStore("postgresql://localhost/unforgit");
@@ -57,6 +66,27 @@ describe("RemoteStore user credential revocation", () => {
     });
     expect(prisma.userRepoAccess.delete).toHaveBeenCalledWith({
       where: { userId_orgId_repoId: accessScope },
+    });
+    expect(prisma.$transaction).toHaveBeenCalledOnce();
+  });
+
+  it("deactivates write-capable API keys when repository access becomes read-only", async () => {
+    const { prisma, store } = buildStore();
+
+    await store.upsertRepoAccess({
+      userId: "user-id",
+      orgId: "Allowed-Org",
+      repoId: "Allowed-Repo",
+      permission: "read",
+    });
+
+    expect(prisma.apiKey.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId: "user-id",
+        orgId: "allowed-org",
+        OR: [{ repoId: "allowed-repo" }, { repoId: null }],
+      },
+      data: { isActive: false },
     });
     expect(prisma.$transaction).toHaveBeenCalledOnce();
   });

--- a/packages/db/src/__tests__/remote-auth.test.ts
+++ b/packages/db/src/__tests__/remote-auth.test.ts
@@ -2,8 +2,28 @@ import { describe, expect, it, vi } from "vitest";
 import { RemoteStore } from "../remote.js";
 
 function buildStore() {
+  const transactionClient = {
+    $queryRaw: vi.fn().mockResolvedValue([{ permission: "write" }]),
+    apiKey: {
+      create: vi.fn().mockResolvedValue({
+        id: "key-id",
+        key: "hk_generated",
+        name: "user-key",
+        label: null,
+        orgId: "allowed-org",
+        repoId: "allowed-repo",
+        userId: "user-id",
+      }),
+    },
+  };
   const prisma = {
-    $transaction: vi.fn(async (operations: unknown[]) => Promise.all(operations)),
+    $transaction: vi.fn(async (operation: unknown) =>
+      typeof operation === "function"
+        ? (operation as (client: typeof transactionClient) => Promise<unknown>)(
+            transactionClient,
+          )
+        : Promise.all(operation as Promise<unknown>[]),
+    ),
     apiKey: {
       updateMany: vi.fn().mockResolvedValue({ count: 1 }),
     },
@@ -27,7 +47,7 @@ function buildStore() {
 
   Object.defineProperty(store, "prisma", { value: prisma });
 
-  return { prisma, store };
+  return { prisma, store, transactionClient };
 }
 
 describe("RemoteStore user credential revocation", () => {
@@ -70,24 +90,65 @@ describe("RemoteStore user credential revocation", () => {
     expect(prisma.$transaction).toHaveBeenCalledOnce();
   });
 
-  it("deactivates write-capable API keys when repository access becomes read-only", async () => {
-    const { prisma, store } = buildStore();
+  it.each(["read", "none"])(
+    "deactivates write-capable API keys when repository access becomes %s",
+    async (permission) => {
+      const { prisma, store } = buildStore();
 
-    await store.upsertRepoAccess({
-      userId: "user-id",
-      orgId: "Allowed-Org",
-      repoId: "Allowed-Repo",
-      permission: "read",
-    });
-
-    expect(prisma.apiKey.updateMany).toHaveBeenCalledWith({
-      where: {
+      await store.upsertRepoAccess({
         userId: "user-id",
-        orgId: "allowed-org",
-        OR: [{ repoId: "allowed-repo" }, { repoId: null }],
-      },
-      data: { isActive: false },
+        orgId: "Allowed-Org",
+        repoId: "Allowed-Repo",
+        permission,
+      });
+
+      expect(prisma.apiKey.updateMany).toHaveBeenCalledWith({
+        where: {
+          userId: "user-id",
+          orgId: "allowed-org",
+          OR: [{ repoId: "allowed-repo" }, { repoId: null }],
+        },
+        data: { isActive: false },
+      });
+      expect(prisma.$transaction).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("locks repository access while creating a user API key", async () => {
+    const { store, transactionClient } = buildStore();
+
+    await expect(
+      store.createApiKeyForUserWithWriteAccess(
+        "user-key",
+        "Allowed-Org",
+        "Allowed-Repo",
+        "user-id",
+        "user-id",
+      ),
+    ).resolves.toMatchObject({
+      id: "key-id",
+      orgId: "allowed-org",
+      repoId: "allowed-repo",
     });
-    expect(prisma.$transaction).toHaveBeenCalledOnce();
+
+    expect(transactionClient.$queryRaw).toHaveBeenCalledOnce();
+    expect(transactionClient.apiKey.create).toHaveBeenCalledOnce();
+  });
+
+  it("does not create a key when locked repository access is read-only", async () => {
+    const { store, transactionClient } = buildStore();
+    transactionClient.$queryRaw.mockResolvedValue([{ permission: "read" }]);
+
+    await expect(
+      store.createApiKeyForUserWithWriteAccess(
+        "user-key",
+        "Allowed-Org",
+        "Allowed-Repo",
+        "user-id",
+        "user-id",
+      ),
+    ).resolves.toBeNull();
+
+    expect(transactionClient.apiKey.create).not.toHaveBeenCalled();
   });
 });

--- a/packages/db/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/db/src/__tests__/sqlite-adapter.test.ts
@@ -35,6 +35,10 @@ describe("NodeSqliteDatabase", () => {
     ]);
   });
 
+  it("waits briefly for concurrent writers instead of failing immediately", () => {
+    expect(db.pragma("busy_timeout")).toEqual([{ timeout: 5000 }]);
+  });
+
   it("returns SQLite blobs as Node buffers", () => {
     db.exec("CREATE TABLE blobs (value BLOB NOT NULL)");
     db.prepare("INSERT INTO blobs (value) VALUES (?)").run(

--- a/packages/db/src/remote.ts
+++ b/packages/db/src/remote.ts
@@ -1661,7 +1661,7 @@ export class RemoteStore {
     const normalizedOrgId = input.orgId.toLowerCase();
     const normalizedRepoId = input.repoId.toLowerCase();
 
-    return this.prisma.userRepoAccess.upsert({
+    const upsertAccess = this.prisma.userRepoAccess.upsert({
       where: {
         userId_orgId_repoId: {
           userId: input.userId,
@@ -1681,6 +1681,23 @@ export class RemoteStore {
         grantedBy: input.grantedBy ?? null,
       },
     });
+
+    if (input.permission.toLowerCase() !== "read") {
+      return upsertAccess;
+    }
+
+    const [access] = await this.prisma.$transaction([
+      upsertAccess,
+      this.prisma.apiKey.updateMany({
+        where: {
+          userId: input.userId,
+          orgId: normalizedOrgId,
+          OR: [{ repoId: normalizedRepoId }, { repoId: null }],
+        },
+        data: { isActive: false },
+      }),
+    ]);
+    return access;
   }
 
   async getUserRepoAccess(userId: string): Promise<Array<{

--- a/packages/db/src/remote.ts
+++ b/packages/db/src/remote.ts
@@ -1682,7 +1682,7 @@ export class RemoteStore {
       },
     });
 
-    if (input.permission.toLowerCase() !== "read") {
+    if (["write", "admin"].includes(input.permission.toLowerCase())) {
       return upsertAccess;
     }
 
@@ -1752,14 +1752,6 @@ export class RemoteStore {
       const normalizedRepoId = repoId.toLowerCase();
 
       await this.prisma.$transaction([
-        this.prisma.apiKey.updateMany({
-          where: {
-            userId,
-            orgId: normalizedOrgId,
-            OR: [{ repoId: normalizedRepoId }, { repoId: null }],
-          },
-          data: { isActive: false },
-        }),
         this.prisma.userRepoAccess.delete({
           where: {
             userId_orgId_repoId: {
@@ -1768,6 +1760,14 @@ export class RemoteStore {
               repoId: normalizedRepoId,
             },
           },
+        }),
+        this.prisma.apiKey.updateMany({
+          where: {
+            userId,
+            orgId: normalizedOrgId,
+            OR: [{ repoId: normalizedRepoId }, { repoId: null }],
+          },
+          data: { isActive: false },
         }),
       ]);
       return true;
@@ -1856,6 +1856,68 @@ export class RemoteStore {
       repoId: apiKey.repoId,
       userId: apiKey.userId!,
     };
+  }
+
+  async createApiKeyForUserWithWriteAccess(
+    name: string,
+    orgId: string,
+    repoId: string,
+    userId: string,
+    createdBy: string,
+    label?: string,
+  ): Promise<{
+    id: string;
+    key: string;
+    name: string;
+    label: string | null;
+    orgId: string;
+    repoId: string;
+    userId: string;
+  } | null> {
+    const key = `hk_${crypto.randomUUID().replace(/-/g, "")}`;
+    const normalizedOrgId = orgId.toLowerCase();
+    const normalizedRepoId = repoId.toLowerCase();
+
+    const apiKey = await this.prisma.$transaction(async (transaction) => {
+      const access = await transaction.$queryRaw<Array<{ permission: string }>>`
+        SELECT permission
+        FROM user_repo_access
+        WHERE user_id = ${userId}::uuid
+          AND org_id = ${normalizedOrgId}
+          AND repo_id = ${normalizedRepoId}
+        FOR UPDATE
+      `;
+      if (
+        !access[0] ||
+        !["write", "admin"].includes(access[0].permission.toLowerCase())
+      ) {
+        return null;
+      }
+
+      return transaction.apiKey.create({
+        data: {
+          key,
+          name,
+          orgId: normalizedOrgId,
+          repoId: normalizedRepoId,
+          userId,
+          createdBy,
+          label: label ?? null,
+        },
+      });
+    });
+
+    return apiKey
+      ? {
+          id: apiKey.id,
+          key: apiKey.key,
+          name: apiKey.name,
+          label: apiKey.label,
+          orgId: apiKey.orgId,
+          repoId: apiKey.repoId!,
+          userId: apiKey.userId!,
+        }
+      : null;
   }
 
   async getUserApiKeys(userId: string): Promise<Array<{

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -72,7 +72,7 @@ export class NodeSqliteDatabase {
   private nextSavepointId = 0;
 
   constructor(path: string) {
-    this.database = new DatabaseSync(path);
+    this.database = new DatabaseSync(path, { timeout: 5000 });
   }
 
   exec(sql: string): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,8 @@ overrides:
   '@babel/core@<=7.29.0': 7.29.7
   nanoid@<3.3.18: 3.3.18
   deepmerge-ts@<8.0.0: 8.0.1
+  browserslist@<=4.28.6: 4.28.8
+  mysql2@<3.22.0: 3.24.3
 
 patchedDependencies:
   minimatch@3.1.5:
@@ -43,7 +45,7 @@ importers:
         version: 17.3.1
       prisma:
         specifier: ^7.8.0
-        version: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 7.8.0(@types/node@25.3.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.4
@@ -214,7 +216,7 @@ importers:
         version: 7.4.2
       '@prisma/client':
         specifier: ^7.4.2
-        version: 7.4.2(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.4.2(prisma@7.8.0(@types/node@25.3.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -526,7 +528,7 @@ importers:
         version: 7.4.2
       '@prisma/client':
         specifier: ^7.4.2
-        version: 7.4.2(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.4.2(prisma@7.8.0(@types/node@25.3.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       pg:
         specifier: ^8.19.0
         version: 8.19.0
@@ -2481,6 +2483,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  baseline-browser-mapping@2.11.20:
+    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   better-result@2.9.2:
     resolution: {integrity: sha512-WIFoBPCdnTOdk9inkE1ZRvCZ4P0CpSkAiLlchC65N7n9DcjZ3NhqkBOlafzpOVnO8ixyi37kicmSJ3ENhPZl7Q==}
 
@@ -2509,8 +2516,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -2553,6 +2560,9 @@ packages:
 
   caniuse-lite@1.0.30001777:
     resolution: {integrity: sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==}
+
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   canvas-color-tracker@1.3.2:
     resolution: {integrity: sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==}
@@ -2778,10 +2788,6 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
-  denque@2.1.0:
-    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
-    engines: {node: '>=0.10'}
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -2829,8 +2835,8 @@ packages:
   effect@3.20.0:
     resolution: {integrity: sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==}
 
-  electron-to-chromium@1.5.307:
-    resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
+  electron-to-chromium@1.5.420:
+    resolution: {integrity: sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -3218,6 +3224,10 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -3547,9 +3557,11 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  mysql2@3.15.3:
-    resolution: {integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==}
+  mysql2@3.24.3:
+    resolution: {integrity: sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==}
     engines: {node: '>= 8.0'}
+    peerDependencies:
+      '@types/node': '>= 8'
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -3619,8 +3631,9 @@ packages:
     resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
     engines: {node: '>=10'}
 
-  node-releases@2.0.36:
-    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
+    engines: {node: '>=18'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4087,9 +4100,6 @@ packages:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
 
-  seq-queue@0.0.5:
-    resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
-
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
@@ -4170,9 +4180,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
-  sqlstring@2.3.3:
-    resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
-    engines: {node: '>= 0.6'}
+  sql-escaper@1.5.1:
+    resolution: {integrity: sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==}
+    engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4383,11 +4393,11 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.8
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -4653,7 +4663,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -5175,11 +5185,11 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.4.2': {}
 
-  '@prisma/client@7.4.2(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
+  '@prisma/client@7.4.2(prisma@7.8.0(@types/node@25.3.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.4.2
     optionalDependencies:
-      prisma: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      prisma: 7.8.0(@types/node@25.3.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       typescript: 5.9.3
 
   '@prisma/config@7.8.0':
@@ -6405,6 +6415,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
+  baseline-browser-mapping@2.11.20: {}
+
   better-result@2.9.2: {}
 
   better-sqlite3@12.6.2:
@@ -6446,13 +6458,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.1:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001777
-      electron-to-chromium: 1.5.307
-      node-releases: 2.0.36
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.420
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
   buffer@5.7.1:
     dependencies:
@@ -6496,6 +6508,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001777: {}
+
+  caniuse-lite@1.0.30001810: {}
 
   canvas-color-tracker@1.3.2:
     dependencies:
@@ -6686,8 +6700,6 @@ snapshots:
 
   defu@6.1.7: {}
 
-  denque@2.1.0: {}
-
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -6728,7 +6740,7 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  electron-to-chromium@1.5.307: {}
+  electron-to-chromium@1.5.420: {}
 
   emoji-regex@8.0.0: {}
 
@@ -7192,6 +7204,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -7439,17 +7455,16 @@ snapshots:
 
   ms@2.1.3: {}
 
-  mysql2@3.15.3:
+  mysql2@3.24.3(@types/node@25.3.3):
     dependencies:
+      '@types/node': 25.3.3
       aws-ssl-profiles: 1.1.2
-      denque: 2.1.0
       generate-function: 2.3.1
-      iconv-lite: 0.7.2
+      iconv-lite: 0.7.3
       long: 5.3.2
       lru.min: 1.1.4
       named-placeholders: 1.1.6
-      seq-queue: 0.0.5
-      sqlstring: 2.3.3
+      sql-escaper: 1.5.1
 
   mz@2.7.0:
     dependencies:
@@ -7522,7 +7537,7 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  node-releases@2.0.36: {}
+  node-releases@2.0.54: {}
 
   object-assign@4.1.1: {}
 
@@ -7716,18 +7731,19 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  prisma@7.8.0(@types/node@25.3.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       '@prisma/config': 7.8.0
       '@prisma/dev': 0.24.3(typescript@5.9.3)
       '@prisma/engines': 7.8.0
       '@prisma/studio-core': 0.27.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      mysql2: 3.15.3
+      mysql2: 3.24.3(@types/node@25.3.3)
       postgres: 3.4.7
     optionalDependencies:
       better-sqlite3: 12.6.2
       typescript: 5.9.3
     transitivePeerDependencies:
+      - '@types/node'
       - '@types/react'
       - '@types/react-dom'
       - magicast
@@ -8018,8 +8034,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  seq-queue@0.0.5: {}
-
   serve-static@2.2.1:
     dependencies:
       encodeurl: 2.0.0
@@ -8164,7 +8178,7 @@ snapshots:
 
   split2@4.2.0: {}
 
-  sqlstring@2.3.3: {}
+  sql-escaper@1.5.1: {}
 
   stackback@0.0.2: {}
 
@@ -8393,9 +8407,9 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
+  update-browserslist-db@1.3.2(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   flatted: 3.4.2
   micromatch>picomatch: 2.3.2
   tinyglobby>picomatch: 4.0.4
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   ip-address: 10.4.0
   hono@<4.12.34: 4.13.0
   sharp@<0.35.0: 0.35.3
@@ -3016,8 +3016,8 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -4881,7 +4881,7 @@ snapshots:
     dependencies:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
 
   '@fastify/cors@11.2.0':
     dependencies:
@@ -6380,7 +6380,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6972,7 +6972,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -6982,7 +6982,7 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fastify-plugin@5.1.0: {}
 
@@ -7280,7 +7280,7 @@ snapshots:
   json-schema-resolver@3.0.0:
     dependencies:
       debug: 4.4.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary
- require GitHub repository write/admin access for self-service API-key creation and recheck it under a row lock
- deactivate user credentials atomically when repository access is revoked or downgraded
- reject invalid admin repository permissions
- fail GitHub OAuth before mutating user/access state when any repository page cannot be fetched
- avoid unsafe automatic deletion of historical access rows until their provenance is authoritative
- restore the 5-second SQLite busy timeout from the previous driver
- patch high-severity Browserslist, mysql2, and fast-uri advisories

## Verification
- `pnpm install --frozen-lockfile` (Node 24.19.0)
- `pnpm db:generate`
- tracked-checkout ESLint gate
- `pnpm test` — 63 files, 356 tests
- `pnpm build`
- `pnpm smoke:cli`
- `pnpm smoke:packed-cli`
- `pnpm audit --audit-level high` — 0 high/critical; 5 moderate remain
- `pnpm audit --prod --audit-level high` — 0 high/critical; 4 moderate remain
- website production audit — 0 vulnerabilities
- website registry signature verification passed
- independent release-blocking review — approved with no Critical/Important findings