### PR TITLE
fix(security): preserve repository API key scope

### DIFF
--- a/apps/admin/app/api/repo/[org]/[repo]/keys/route.ts
+++ b/apps/admin/app/api/repo/[org]/[repo]/keys/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { filterRepositoryApiKeys } from "@/lib/api-key-scope";
 
 const API_URL = process.env.API_URL || process.env.UNFORGIT_API_URL || "http://localhost:3737";
 
@@ -6,7 +7,7 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ org: string; repo: string }> }
 ) {
-  const { org } = await params;
+  const { org, repo } = await params;
   const authHeader = request.headers.get("Authorization");
 
   if (!authHeader) {
@@ -30,9 +31,7 @@ export async function GET(
 
     const data = await res.json();
     
-    const filteredKeys = (data.keys || []).filter((key: { orgId: string }) => 
-      key.orgId === org
-    );
+    const filteredKeys = filterRepositoryApiKeys(data.keys || [], org, repo);
 
     return NextResponse.json({ keys: filteredKeys });
   } catch (error) {

--- a/apps/admin/components/create-key-dialog.tsx
+++ b/apps/admin/components/create-key-dialog.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Copy, Check, Loader2, Plus, X } from "lucide-react";
 import { apiFetch } from "@/lib/api";
+import { buildRepositoryApiKeyPayload } from "@/lib/api-key-scope";
 import { toast } from "sonner";
 
 interface CreatedKey {
@@ -11,6 +12,7 @@ interface CreatedKey {
   name: string;
   label?: string | null;
   orgId: string;
+  repoId: string;
 }
 
 interface RepoOption {
@@ -60,7 +62,9 @@ export function CreateKeyDialog({ open, onClose, onCreated, repo, userId, userRe
       } else if (parsed) {
         data = await apiFetch<CreatedKey>("/api/keys", {
           method: "POST",
-          body: JSON.stringify({ name: parsed.name, orgId: parsed.orgId, label: keyLabel }),
+          body: JSON.stringify(
+            buildRepositoryApiKeyPayload(parsed.orgId, parsed.repoId, keyLabel),
+          ),
         });
       } else {
         throw new Error("No repository selected");

--- a/apps/admin/lib/api-key-scope.ts
+++ b/apps/admin/lib/api-key-scope.ts
@@ -1,0 +1,32 @@
+interface RepositoryApiKey {
+  orgId: string;
+  repoId: string | null;
+}
+
+export function buildRepositoryApiKeyPayload(
+  orgId: string,
+  repoId: string,
+  label?: string,
+): { name: string; orgId: string; repoId: string; label?: string } {
+  return {
+    name: `${orgId}/${repoId}`,
+    orgId,
+    repoId,
+    label,
+  };
+}
+
+export function filterRepositoryApiKeys<T extends RepositoryApiKey>(
+  keys: T[],
+  orgId: string,
+  repoId: string,
+): T[] {
+  const normalizedOrgId = orgId.toLowerCase();
+  const normalizedRepoId = repoId.toLowerCase();
+
+  return keys.filter(
+    (key) =>
+      key.orgId.toLowerCase() === normalizedOrgId &&
+      key.repoId?.toLowerCase() === normalizedRepoId,
+  );
+}

--- a/apps/admin/src/__tests__/api-key-scope.test.ts
+++ b/apps/admin/src/__tests__/api-key-scope.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRepositoryApiKeyPayload,
+  filterRepositoryApiKeys,
+} from "../../lib/api-key-scope";
+
+describe("repository API key scope", () => {
+  it("includes the repository in key creation payloads", () => {
+    expect(
+      buildRepositoryApiKeyPayload("Allowed-Org", "Allowed-Repo", "automation"),
+    ).toEqual({
+      name: "Allowed-Org/Allowed-Repo",
+      orgId: "Allowed-Org",
+      repoId: "Allowed-Repo",
+      label: "automation",
+    });
+  });
+
+  it("filters out organization-wide and sibling repository keys", () => {
+    const keys = [
+      { id: "target", orgId: "allowed-org", repoId: "allowed-repo" },
+      { id: "org-wide", orgId: "allowed-org", repoId: null },
+      { id: "sibling", orgId: "allowed-org", repoId: "other-repo" },
+      { id: "other-org", orgId: "other-org", repoId: "allowed-repo" },
+    ];
+
+    expect(filterRepositoryApiKeys(keys, "Allowed-Org", "Allowed-Repo")).toEqual([
+      keys[0],
+    ]);
+  });
+});

--- a/apps/api/src/__tests__/admin-auth.test.ts
+++ b/apps/api/src/__tests__/admin-auth.test.ts
@@ -134,6 +134,46 @@ describe("admin auth", () => {
     await app.close();
   });
 
+  it("preserves repository scope when creating an API key", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    const store = buildStore();
+    store.createApiKey.mockResolvedValue({
+      id: "created-key-id",
+      key: "hk_created",
+      name: "Allowed-Org/Allowed-Repo",
+      label: "automation",
+      orgId: "allowed-org",
+      repoId: "allowed-repo",
+    });
+    const token = await signAdminToken();
+    const app = await buildAdminApp(store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/admin/api-keys",
+      headers: adminAuthorization(token),
+      payload: {
+        name: "Allowed-Org/Allowed-Repo",
+        orgId: "Allowed-Org",
+        repoId: "Allowed-Repo",
+        label: "automation",
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(store.createApiKey).toHaveBeenCalledWith(
+      "Allowed-Org/Allowed-Repo",
+      "Allowed-Org",
+      { label: "automation", repoId: "Allowed-Repo" },
+    );
+    expect(response.json()).toMatchObject({
+      orgId: "allowed-org",
+      repoId: "allowed-repo",
+    });
+
+    await app.close();
+  });
+
   it("returns a bad request instead of crashing when granting repo access without a body", async () => {
     process.env.JWT_SECRET = "test-secret";
     const store = buildStore();

--- a/apps/api/src/__tests__/admin-auth.test.ts
+++ b/apps/api/src/__tests__/admin-auth.test.ts
@@ -174,6 +174,41 @@ describe("admin auth", () => {
     await app.close();
   });
 
+  it("returns repository scope when listing API keys", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    const store = buildStore();
+    store.listApiKeysWithUsers.mockResolvedValue([
+      {
+        id: "key-id",
+        key: "hk_repository_key",
+        name: "allowed-org/allowed-repo",
+        label: null,
+        orgId: "allowed-org",
+        repoId: "allowed-repo",
+        userId: null,
+        isActive: true,
+        createdAt: new Date("2026-09-04T12:00:00.000Z"),
+        lastUsedAt: null,
+        user: null,
+      },
+    ]);
+    const token = await signAdminToken();
+    const app = await buildAdminApp(store);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/admin/api-keys",
+      headers: adminAuthorization(token),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      keys: [{ id: "key-id", repoId: "allowed-repo" }],
+    });
+
+    await app.close();
+  });
+
   it("returns a bad request instead of crashing when granting repo access without a body", async () => {
     process.env.JWT_SECRET = "test-secret";
     const store = buildStore();

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -176,6 +176,7 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
           name: k.name,
           label: k.label,
           orgId: k.orgId,
+          repoId: k.repoId,
           isActive: k.isActive,
           createdAt: k.createdAt.toISOString(),
           lastUsedAt: k.lastUsedAt?.toISOString() ?? null,
@@ -195,7 +196,7 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
     "/v1/admin/api-keys",
     { preHandler: requireAdmin },
     async (request, reply) => {
-      const { name, orgId, label } = request.body ?? {};
+      const { name, orgId, repoId, label } = request.body ?? {};
 
       if (!name || !orgId) {
         return reply
@@ -203,7 +204,7 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
           .send({ error: "Bad Request", message: "name and orgId are required" });
       }
 
-      const apiKey = await store.createApiKey(name, orgId, label);
+      const apiKey = await store.createApiKey(name, orgId, { label, repoId });
 
       return reply.status(201).send({
         id: apiKey.id,
@@ -211,6 +212,7 @@ export const adminRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         name: apiKey.name,
         label: apiKey.label,
         orgId: apiKey.orgId,
+        repoId: apiKey.repoId,
       });
     },
   );

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
       "deepmerge-ts@<8.0.0": "8.0.1",
       "browserslist@<=4.28.6": "4.28.8",
       "mysql2@<3.22.0": "3.24.3",
-      "@humanfs/node@<0.16.8": "0.16.8"
+      "@humanfs/node@<0.16.8": "0.16.8",
+      "fflate@<0.8.3": "0.8.3"
     },
     "patchedDependencies": {
       "minimatch@3.1.5": "patches/minimatch@3.1.5.patch"

--- a/packages/db/src/__tests__/remote-auth.test.ts
+++ b/packages/db/src/__tests__/remote-auth.test.ts
@@ -25,6 +25,14 @@ function buildStore() {
         : Promise.all(operation as Promise<unknown>[]),
     ),
     apiKey: {
+      create: vi.fn().mockResolvedValue({
+        id: "key-id",
+        key: "hk_generated",
+        name: "repo-key",
+        label: "automation",
+        orgId: "allowed-org",
+        repoId: "allowed-repo",
+      }),
       updateMany: vi.fn().mockResolvedValue({ count: 1 }),
     },
     user: {
@@ -51,6 +59,30 @@ function buildStore() {
 }
 
 describe("RemoteStore user credential revocation", () => {
+  it("persists normalized repository scope when creating an API key", async () => {
+    const { prisma, store } = buildStore();
+
+    await expect(
+      store.createApiKey("repo-key", "Allowed-Org", {
+        label: "automation",
+        repoId: "Allowed-Repo",
+      }),
+    ).resolves.toMatchObject({
+      orgId: "allowed-org",
+      repoId: "allowed-repo",
+    });
+
+    expect(prisma.apiKey.create).toHaveBeenCalledWith({
+      data: {
+        key: expect.stringMatching(/^hk_[a-f0-9]{32}$/),
+        name: "repo-key",
+        orgId: "allowed-org",
+        repoId: "allowed-repo",
+        label: "automation",
+      },
+    });
+  });
+
   it("deactivates a user's API keys when deleting the user", async () => {
     const { prisma, store } = buildStore();
 

--- a/packages/db/src/__tests__/remote-auth.test.ts
+++ b/packages/db/src/__tests__/remote-auth.test.ts
@@ -83,6 +83,36 @@ describe("RemoteStore user credential revocation", () => {
     });
   });
 
+  it("preserves the legacy label argument for organization-wide API keys", async () => {
+    const { prisma, store } = buildStore();
+    prisma.apiKey.create.mockResolvedValueOnce({
+      id: "key-id",
+      key: "hk_generated",
+      name: "organization-key",
+      label: "automation",
+      orgId: "allowed-org",
+      repoId: null,
+    });
+
+    await expect(
+      store.createApiKey("organization-key", "Allowed-Org", "automation"),
+    ).resolves.toMatchObject({
+      orgId: "allowed-org",
+      repoId: null,
+      label: "automation",
+    });
+
+    expect(prisma.apiKey.create).toHaveBeenCalledWith({
+      data: {
+        key: expect.stringMatching(/^hk_[a-f0-9]{32}$/),
+        name: "organization-key",
+        orgId: "allowed-org",
+        repoId: null,
+        label: "automation",
+      },
+    });
+  });
+
   it("deactivates a user's API keys when deleting the user", async () => {
     const { prisma, store } = buildStore();
 

--- a/packages/db/src/remote.ts
+++ b/packages/db/src/remote.ts
@@ -943,15 +943,30 @@ export class RemoteStore {
     };
   }
 
-  async createApiKey(name: string, orgId: string, label?: string): Promise<{ id: string; key: string; name: string; orgId: string; label: string | null }> {
+  async createApiKey(
+    name: string,
+    orgId: string,
+    options: string | { label?: string; repoId?: string } = {},
+  ): Promise<{
+    id: string;
+    key: string;
+    name: string;
+    orgId: string;
+    repoId: string | null;
+    label: string | null;
+  }> {
     const key = `hk_${crypto.randomUUID().replace(/-/g, "")}`;
     const normalizedOrgId = orgId.toLowerCase();
+    const label = typeof options === "string" ? options : options.label;
+    const normalizedRepoId =
+      typeof options === "string" ? null : options.repoId?.toLowerCase() ?? null;
 
     const apiKey = await this.prisma.apiKey.create({
       data: {
         key,
         name,
         orgId: normalizedOrgId,
+        repoId: normalizedRepoId,
         label: label ?? null,
       },
     });
@@ -961,6 +976,7 @@ export class RemoteStore {
       key: apiKey.key,
       name: apiKey.name,
       orgId: apiKey.orgId,
+      repoId: apiKey.repoId,
       label: apiKey.label,
     };
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,7 @@ overrides:
   browserslist@<=4.28.6: 4.28.8
   mysql2@<3.22.0: 3.24.3
   '@humanfs/node@<0.16.8': 0.16.8
+  fflate@<0.8.3: 0.8.3
 
 patchedDependencies:
   minimatch@3.1.5:
@@ -3053,8 +3054,8 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -6211,7 +6212,7 @@ snapshots:
       '@types/stats.js': 0.17.4
       '@types/webxr': 0.5.24
       '@webgpu/types': 0.1.69
-      fflate: 0.8.2
+      fflate: 0.8.3
       meshoptimizer: 1.0.1
 
   '@types/use-sync-external-store@0.0.6': {}
@@ -7042,7 +7043,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  fflate@0.8.2: {}
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- preserve repository scope when admins create repository API keys
- keep the legacy organization-wide labeled-key API compatible
- filter repository key pages by both organization and repository
- update transitive `fflate` from vulnerable 0.8.2 to patched 0.8.3
- add regression coverage across UI payload, API, persistence, and filtering boundaries

## Security impact
Repository-targeted keys were stored without `repoId`, unintentionally granting organization-wide access. The dependency update resolves GHSA-px8p-9vwx-vf98.

## Verification
- [x] Regression tests failed on the previous implementation
- [x] Node 24 full suite: 64 files / 362 tests
- [x] Full build and CLI smoke
- [x] Tracked-source ESLint: 0 errors
- [x] `pnpm audit`: 0 vulnerabilities
- [x] Website `npm audit`: 0 vulnerabilities
- [x] npm registry signatures and attestations verified
- [x] Docker Compose rebuild and HTTP smoke checks
- [x] CI and CodeQL pass
- [x] Independent security review pass