### PR TITLE
fix(api): report failed account deletion

### DIFF
--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -332,4 +332,31 @@ describe("auth routes", () => {
       await app.close();
     },
   );
+
+  it("does not report success when account deletion fails", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    const store = {
+      getUserById: vi.fn().mockResolvedValue({ id: "user-id" }),
+      deleteUser: vi.fn().mockResolvedValue(false),
+    } as unknown as RemoteStore & {
+      getUserById: ReturnType<typeof vi.fn>;
+      deleteUser: ReturnType<typeof vi.fn>;
+    };
+    const token = await signUserToken();
+    const app = await buildApp(store);
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/v1/auth/delete-account",
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toMatchObject({
+      success: false,
+      message: "Failed to delete account",
+    });
+
+    await app.close();
+  });
 });

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -744,7 +744,15 @@ export const authRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
       });
     }
 
-    await store.deleteUser(user.id);
+    const deleted = await store.deleteUser(user.id);
+
+    if (!deleted) {
+      return reply.status(500).send({
+        success: false,
+        error: "Internal Server Error",
+        message: "Failed to delete account",
+      });
+    }
 
     return reply.send({ success: true, message: "Account deleted successfully" });
   });


### PR DESCRIPTION
## Summary
- return an HTTP 500 response when the account deletion transaction fails
- avoid falsely telling users that their account and credentials were deleted
- cover the failure path with an API regression test

## TDD evidence
- RED: focused regression returned HTTP 200 instead of 500
- GREEN: focused regression and full auth route suite pass

## Verification
- `pnpm exec vitest run apps/api/src/__tests__/auth.test.ts` — 11 passed
- Node 24 Docker: `pnpm test` — 64 files / 363 tests passed
- Node 24 Docker: `pnpm build`
- Node 24 Docker: `pnpm smoke:cli`
- Node 24 Docker: `pnpm smoke:packed-cli`
- tracked-source ESLint — 0 errors
- `pnpm audit` and website `npm audit` — 0 vulnerabilities
- Docker Compose rebuild; API `/health`, admin `/`, and website `/` verified
- GitHub CI and CodeQL green