### PR TITLE
fix(sync): propagate local memory deprecation

### DIFF
--- a/apps/cli/src/__tests__/commands/push-pull.test.ts
+++ b/apps/cli/src/__tests__/commands/push-pull.test.ts
@@ -4,12 +4,17 @@ import { once } from "node:events";
 import { createTempDataDir, mockFetch, restoreFetch, runCommand } from "../helpers.js";
 import { LocalStore } from "unforgit-db";
 
-async function startRecordingServer(): Promise<{
+async function startRecordingServer(options: { beforeResponse?: () => Promise<void> } = {}): Promise<{
   url: string;
   requests: Array<{ method?: string; url?: string; body: string }>;
+  firstRequest: Promise<void>;
   close: () => Promise<void>;
 }> {
   const requests: Array<{ method?: string; url?: string; body: string }> = [];
+  let resolveFirstRequest: () => void;
+  const firstRequest = new Promise<void>((resolve) => {
+    resolveFirstRequest = resolve;
+  });
   const server = createServer(async (request, response) => {
     const chunks: Buffer[] = [];
     for await (const chunk of request) chunks.push(Buffer.from(chunk));
@@ -18,6 +23,8 @@ async function startRecordingServer(): Promise<{
       url: request.url,
       body: Buffer.concat(chunks).toString("utf8"),
     });
+    resolveFirstRequest!();
+    await options.beforeResponse?.();
     response.writeHead(200, { "content-type": "application/json" });
     response.end(JSON.stringify({ ok: true }));
   });
@@ -29,6 +36,7 @@ async function startRecordingServer(): Promise<{
   return {
     url: `http://127.0.0.1:${address.port}`,
     requests,
+    firstRequest,
     close: () => new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     }),
@@ -109,7 +117,7 @@ describe("push/pull logic", () => {
       expect(deprecated[0].sourceRefs).toMatchObject({ deprecation_reason: "outdated" });
       expect(store.getSyncState(memory.id)?.syncStatus).toBe("pending_push");
 
-      store.markStatusSynced(memory.id);
+      store.markStatusSynced(memory.id, deprecated[0].version);
 
       expect(store.getDeprecatedMemoriesToSync("test-org", "test-repo")).toEqual([]);
       expect(store.getSyncState(memory.id)?.localVersion).toBe(memory.version + 1);
@@ -131,6 +139,34 @@ describe("push/pull logic", () => {
         localVersion: memory.version + 1,
         syncStatus: "synced",
       });
+    });
+
+    it("does not queue a deprecated memory just pulled from remote", () => {
+      const memory = {
+        id: "remote-deprecated",
+        orgId: "test-org",
+        repoId: "test-repo",
+        scopeType: "repo" as const,
+        memoryType: "episodic" as const,
+        visibility: "repo" as const,
+        status: "deprecated" as const,
+        text: "already deprecated remotely",
+        tags: [],
+        version: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      store.upsertFromRemote(memory);
+      store.setSyncState({
+        memoryId: memory.id,
+        localVersion: memory.version,
+        remoteVersion: memory.version,
+        lastPulledAt: new Date(),
+        syncStatus: "synced",
+      });
+
+      expect(store.getDeprecatedMemoriesToSync("test-org", "test-repo")).toEqual([]);
     });
 
     it("pushes local deprecation to the remote API", async () => {
@@ -175,6 +211,60 @@ describe("push/pull logic", () => {
       }
     });
 
+    it("keeps a newer local deprecation pending while an older version is in flight", async () => {
+      let releaseResponse: () => void;
+      const responseGate = new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+      });
+      const remote = await startRecordingServer({ beforeResponse: () => responseGate });
+
+      try {
+        store.close();
+        tmp.cleanup();
+        tmp = createTempDataDir({
+          remote: {
+            url: remote.url,
+            orgId: "test-org",
+            repoId: "test-repo",
+          },
+        });
+        store = new LocalStore(tmp.dbPath);
+        const memory = store.store({
+          orgId: "test-org",
+          repoId: "test-repo",
+          memoryType: "episodic",
+          text: "concurrent deprecation",
+          visibility: "repo",
+        });
+        store.markAsPushed(memory.id, memory.version);
+        store.deprecate(memory.id, "reason A");
+        store.close();
+
+        const pushResult = runCommand(["push"], { cwd: tmp.dir });
+        await remote.firstRequest;
+        const concurrentStore = new LocalStore(tmp.dbPath);
+        concurrentStore.deprecate(memory.id, "reason B");
+        concurrentStore.close();
+        releaseResponse!();
+
+        expect((await pushResult).exitCode).toBe(0);
+        store = new LocalStore(tmp.dbPath);
+        const pending = store.getDeprecatedMemoriesToSync("test-org", "test-repo");
+        expect(pending).toHaveLength(1);
+        expect(pending[0]).toMatchObject({
+          id: memory.id,
+          version: memory.version + 2,
+          sourceRefs: { deprecation_reason: "reason B" },
+        });
+        expect(store.getSyncState(memory.id)?.syncStatus).toBe("pending_push");
+        expect(remote.requests).toHaveLength(1);
+        expect(remote.requests[0].body).toBe(JSON.stringify({ reason: "reason A" }));
+      } finally {
+        releaseResponse!();
+        await remote.close();
+      }
+    });
+
     it("does not push a private deprecation without force", async () => {
       const remote = await startRecordingServer();
 
@@ -206,6 +296,43 @@ describe("push/pull logic", () => {
         expect(result.exitCode).toBe(0);
         expect(remote.requests).toEqual([]);
         expect(store.getDeprecatedMemoriesToSync("test-org", "test-repo")).toHaveLength(1);
+      } finally {
+        await remote.close();
+      }
+    });
+
+    it("does not initialize sync state for a legacy local deprecated memory", async () => {
+      const remote = await startRecordingServer();
+
+      try {
+        store.close();
+        tmp.cleanup();
+        tmp = createTempDataDir({
+          remote: {
+            url: remote.url,
+            orgId: "test-org",
+            repoId: "test-repo",
+          },
+        });
+        store = new LocalStore(tmp.dbPath);
+        const memory = store.store({
+          orgId: "test-org",
+          repoId: "test-repo",
+          memoryType: "episodic",
+          text: "legacy local deprecated memory",
+          visibility: "repo",
+        });
+        store.deprecate(memory.id, "never existed remotely");
+        const db = (store as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } }).db;
+        db.prepare("DELETE FROM sync_state WHERE memory_id = ?").run(memory.id);
+        store.close();
+
+        const result = await runCommand(["push", "--all"], { cwd: tmp.dir });
+        store = new LocalStore(tmp.dbPath);
+
+        expect(result.exitCode).toBe(0);
+        expect(remote.requests).toEqual([]);
+        expect(store.getSyncState(memory.id)).toBeUndefined();
       } finally {
         await remote.close();
       }

--- a/apps/cli/src/__tests__/commands/push-pull.test.ts
+++ b/apps/cli/src/__tests__/commands/push-pull.test.ts
@@ -265,6 +265,229 @@ describe("push/pull logic", () => {
       }
     });
 
+    it("keeps a local deprecation pending when an ordinary memory push is in flight", async () => {
+      let releaseResponse: () => void;
+      const responseGate = new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+      });
+      const remote = await startRecordingServer({ beforeResponse: () => responseGate });
+
+      try {
+        store.close();
+        tmp.cleanup();
+        tmp = createTempDataDir({
+          remote: {
+            url: remote.url,
+            orgId: "test-org",
+            repoId: "test-repo",
+          },
+        });
+        store = new LocalStore(tmp.dbPath);
+        const memory = store.store({
+          orgId: "test-org",
+          repoId: "test-repo",
+          memoryType: "episodic",
+          text: "deprecate during initial push",
+          visibility: "repo",
+        });
+        store.close();
+
+        const pushResult = runCommand(["push"], { cwd: tmp.dir });
+        await remote.firstRequest;
+        const concurrentStore = new LocalStore(tmp.dbPath);
+        concurrentStore.deprecate(memory.id, "cancelled while create was in flight");
+        concurrentStore.close();
+        releaseResponse!();
+
+        expect((await pushResult).exitCode).toBe(0);
+        store = new LocalStore(tmp.dbPath);
+        expect(store.getDeprecatedMemoriesToSync("test-org", "test-repo")).toEqual([
+          expect.objectContaining({
+            id: memory.id,
+            version: memory.version + 1,
+            status: "deprecated",
+          }),
+        ]);
+        expect(store.getSyncState(memory.id)?.syncStatus).toBe("pending_push");
+        expect(remote.requests).toHaveLength(1);
+        expect(remote.requests[0]).toMatchObject({
+          method: "POST",
+          url: "/v1/memory",
+        });
+      } finally {
+        releaseResponse!();
+        await remote.close();
+      }
+    });
+
+    it("does not create a stale remote memory after lifecycle queues are captured", async () => {
+      let releaseResponse: () => void;
+      const responseGate = new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+      });
+      const remote = await startRecordingServer({ beforeResponse: () => responseGate });
+
+      try {
+        store.close();
+        tmp.cleanup();
+        tmp = createTempDataDir({
+          remote: {
+            url: remote.url,
+            orgId: "test-org",
+            repoId: "test-repo",
+          },
+        });
+        store = new LocalStore(tmp.dbPath);
+        const first = store.store({
+          orgId: "test-org",
+          repoId: "test-repo",
+          memoryType: "episodic",
+          text: "first queued memory",
+          visibility: "repo",
+        });
+        const second = store.store({
+          orgId: "test-org",
+          repoId: "test-repo",
+          memoryType: "episodic",
+          text: "second queued memory",
+          visibility: "repo",
+        });
+        const db = (store as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } }).db;
+        db.prepare("UPDATE memories SET updated_at = ? WHERE id = ?").run("2000-01-01T00:00:00.000Z", first.id);
+        db.prepare("UPDATE memories SET updated_at = ? WHERE id = ?").run("2001-01-01T00:00:00.000Z", second.id);
+        store.close();
+
+        const pushResult = runCommand(["push"], { cwd: tmp.dir });
+        await remote.firstRequest;
+        const concurrentStore = new LocalStore(tmp.dbPath);
+        concurrentStore.deprecate(second.id, "changed after queue capture");
+        concurrentStore.close();
+        releaseResponse!();
+
+        expect((await pushResult).exitCode).toBe(0);
+        store = new LocalStore(tmp.dbPath);
+        expect(remote.requests).toHaveLength(1);
+        expect(JSON.parse(remote.requests[0].body)).toMatchObject({ id: first.id });
+        expect(store.getById(second.id)).toMatchObject({
+          id: second.id,
+          status: "deprecated",
+          version: second.version + 1,
+        });
+        expect(store.getSyncState(second.id)).toMatchObject({
+          syncStatus: "synced",
+          lastPushedAt: undefined,
+        });
+        expect(store.getSyncState(second.id)?.remoteVersion).toBeNull();
+      } finally {
+        releaseResponse!();
+        await remote.close();
+      }
+    });
+
+    it("keeps a newer supersede target pending while an older target is in flight", async () => {
+      let releaseResponse: () => void;
+      const responseGate = new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+      });
+      const remote = await startRecordingServer({ beforeResponse: () => responseGate });
+
+      try {
+        store.close();
+        tmp.cleanup();
+        tmp = createTempDataDir({
+          remote: {
+            url: remote.url,
+            orgId: "test-org",
+            repoId: "test-repo",
+          },
+        });
+        store = new LocalStore(tmp.dbPath);
+        const memory = store.store({
+          orgId: "test-org",
+          repoId: "test-repo",
+          memoryType: "episodic",
+          text: "supersede concurrently",
+          visibility: "repo",
+        });
+        const replacementA = store.store({
+          orgId: "test-org",
+          repoId: "test-repo",
+          memoryType: "episodic",
+          text: "replacement A",
+          visibility: "repo",
+        });
+        const replacementB = store.store({
+          orgId: "test-org",
+          repoId: "test-repo",
+          memoryType: "episodic",
+          text: "replacement B",
+          visibility: "repo",
+        });
+        for (const item of [memory, replacementA, replacementB]) {
+          store.markAsPushed(item.id, item.version);
+        }
+        store.setSyncState({
+          memoryId: memory.id,
+          localVersion: memory.version,
+          remoteVersion: memory.version,
+          lastPushedAt: new Date("2000-01-01T00:00:00.000Z"),
+          syncStatus: "synced",
+        });
+        store.supersede(memory.id, replacementA.id);
+        store.close();
+
+        const pushResult = runCommand(["push"], { cwd: tmp.dir });
+        await remote.firstRequest;
+        const concurrentStore = new LocalStore(tmp.dbPath);
+        concurrentStore.supersede(memory.id, replacementB.id);
+        concurrentStore.close();
+        releaseResponse!();
+
+        expect((await pushResult).exitCode).toBe(0);
+        store = new LocalStore(tmp.dbPath);
+        expect(store.getSupersededMemoriesToSync("test-org", "test-repo")).toEqual([
+          expect.objectContaining({
+            memory: expect.objectContaining({
+              id: memory.id,
+              version: memory.version + 2,
+            }),
+            newId: replacementB.id,
+          }),
+        ]);
+        expect(store.getSyncState(memory.id)?.syncStatus).toBe("pending_push");
+        expect(remote.requests).toEqual([
+          {
+            method: "POST",
+            url: `/v1/memory/${memory.id}/supersede`,
+            body: JSON.stringify({ newId: replacementA.id }),
+          },
+        ]);
+      } finally {
+        releaseResponse!();
+        await remote.close();
+      }
+    });
+
+    it("does not acknowledge a status push after sync state becomes conflicted", () => {
+      const memory = store.store({
+        orgId: "test-org",
+        repoId: "test-repo",
+        memoryType: "episodic",
+        text: "conflicted status update",
+        visibility: "repo",
+      });
+      store.markAsPushed(memory.id, memory.version);
+      store.deprecate(memory.id, "outdated");
+      const deprecated = store.getById(memory.id)!;
+      store.markAsConflict(memory.id, memory.version + 1);
+
+      expect(store.markStatusSynced(memory.id, deprecated.version)).toBe(false);
+      expect(store.getSyncState(memory.id)).toMatchObject({
+        syncStatus: "conflict",
+        remoteVersion: memory.version + 1,
+      });
+    });
+
     it("does not push a private deprecation without force", async () => {
       const remote = await startRecordingServer();
 
@@ -296,6 +519,50 @@ describe("push/pull logic", () => {
         expect(result.exitCode).toBe(0);
         expect(remote.requests).toEqual([]);
         expect(store.getDeprecatedMemoriesToSync("test-org", "test-repo")).toHaveLength(1);
+      } finally {
+        await remote.close();
+      }
+    });
+
+    it("does not push a private supersede status without force", async () => {
+      const remote = await startRecordingServer();
+
+      try {
+        store.close();
+        tmp.cleanup();
+        tmp = createTempDataDir({
+          remote: {
+            url: remote.url,
+            orgId: "test-org",
+            repoId: "test-repo",
+          },
+        });
+        store = new LocalStore(tmp.dbPath);
+        const memory = store.store({
+          orgId: "test-org",
+          repoId: "test-repo",
+          memoryType: "episodic",
+          text: "previously force-pushed private memory",
+          visibility: "private",
+        });
+        const replacement = store.store({
+          orgId: "test-org",
+          repoId: "test-repo",
+          memoryType: "episodic",
+          text: "private replacement",
+          visibility: "private",
+        });
+        store.markAsPushed(memory.id, memory.version);
+        store.markAsPushed(replacement.id, replacement.version);
+        store.supersede(memory.id, replacement.id);
+        store.close();
+
+        const result = await runCommand(["push"], { cwd: tmp.dir });
+        store = new LocalStore(tmp.dbPath);
+
+        expect(result.exitCode).toBe(0);
+        expect(remote.requests).toEqual([]);
+        expect(store.getSupersededMemoriesToSync("test-org", "test-repo")).toHaveLength(1);
       } finally {
         await remote.close();
       }

--- a/apps/cli/src/__tests__/commands/push-pull.test.ts
+++ b/apps/cli/src/__tests__/commands/push-pull.test.ts
@@ -1,6 +1,39 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { createTempDataDir, mockFetch, restoreFetch } from "../helpers.js";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { createTempDataDir, mockFetch, restoreFetch, runCommand } from "../helpers.js";
 import { LocalStore } from "unforgit-db";
+
+async function startRecordingServer(): Promise<{
+  url: string;
+  requests: Array<{ method?: string; url?: string; body: string }>;
+  close: () => Promise<void>;
+}> {
+  const requests: Array<{ method?: string; url?: string; body: string }> = [];
+  const server = createServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.from(chunk));
+    requests.push({
+      method: request.method,
+      url: request.url,
+      body: Buffer.concat(chunks).toString("utf8"),
+    });
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ ok: true }));
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Test server did not bind to TCP");
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    }),
+  };
+}
 
 describe("push/pull logic", () => {
   let tmp: ReturnType<typeof createTempDataDir>;
@@ -74,11 +107,108 @@ describe("push/pull logic", () => {
       expect(deprecated[0].status).toBe("deprecated");
       expect(deprecated[0].version).toBe(memory.version + 1);
       expect(deprecated[0].sourceRefs).toMatchObject({ deprecation_reason: "outdated" });
+      expect(store.getSyncState(memory.id)?.syncStatus).toBe("pending_push");
 
       store.markStatusSynced(memory.id);
 
       expect(store.getDeprecatedMemoriesToSync("test-org", "test-repo")).toEqual([]);
       expect(store.getSyncState(memory.id)?.localVersion).toBe(memory.version + 1);
+    });
+
+    it("keeps never-synced deprecation local", () => {
+      const memory = store.store({
+        orgId: "test-org",
+        repoId: "test-repo",
+        memoryType: "episodic",
+        text: "private memory deprecated before first push",
+        visibility: "private",
+      });
+
+      store.deprecate(memory.id, "local-only reason");
+
+      expect(store.getDeprecatedMemoriesToSync("test-org", "test-repo")).toEqual([]);
+      expect(store.getSyncState(memory.id)).toMatchObject({
+        localVersion: memory.version + 1,
+        syncStatus: "synced",
+      });
+    });
+
+    it("pushes local deprecation to the remote API", async () => {
+      const remote = await startRecordingServer();
+
+      try {
+        store.close();
+        tmp.cleanup();
+        tmp = createTempDataDir({
+          remote: {
+            url: remote.url,
+            orgId: "test-org",
+            repoId: "test-repo",
+          },
+        });
+        store = new LocalStore(tmp.dbPath);
+        const memory = store.store({
+          orgId: "test-org",
+          repoId: "test-repo",
+          memoryType: "episodic",
+          text: "sync this deprecation",
+          visibility: "repo",
+        });
+        store.markAsPushed(memory.id, memory.version);
+        store.deprecate(memory.id, "replaced by current guidance");
+        store.close();
+
+        const result = await runCommand(["push"], { cwd: tmp.dir });
+        store = new LocalStore(tmp.dbPath);
+
+        expect(result.exitCode).toBe(0);
+        expect(remote.requests).toEqual([
+          {
+            method: "POST",
+            url: `/v1/memory/${memory.id}/deprecate`,
+            body: JSON.stringify({ reason: "replaced by current guidance" }),
+          },
+        ]);
+        expect(store.getDeprecatedMemoriesToSync("test-org", "test-repo")).toEqual([]);
+      } finally {
+        await remote.close();
+      }
+    });
+
+    it("does not push a private deprecation without force", async () => {
+      const remote = await startRecordingServer();
+
+      try {
+        store.close();
+        tmp.cleanup();
+        tmp = createTempDataDir({
+          remote: {
+            url: remote.url,
+            orgId: "test-org",
+            repoId: "test-repo",
+          },
+        });
+        store = new LocalStore(tmp.dbPath);
+        const memory = store.store({
+          orgId: "test-org",
+          repoId: "test-repo",
+          memoryType: "episodic",
+          text: "previously force-pushed private memory",
+          visibility: "private",
+        });
+        store.markAsPushed(memory.id, memory.version);
+        store.deprecate(memory.id, "sensitive local reason");
+        store.close();
+
+        const result = await runCommand(["push"], { cwd: tmp.dir });
+        store = new LocalStore(tmp.dbPath);
+
+        expect(result.exitCode).toBe(0);
+        expect(remote.requests).toEqual([]);
+        expect(store.getDeprecatedMemoriesToSync("test-org", "test-repo")).toHaveLength(1);
+      } finally {
+        await remote.close();
+      }
     });
 
     it("marks as conflict on version mismatch", () => {

--- a/apps/cli/src/__tests__/commands/push-pull.test.ts
+++ b/apps/cli/src/__tests__/commands/push-pull.test.ts
@@ -54,6 +54,33 @@ describe("push/pull logic", () => {
       expect(syncState?.remoteVersion).toBe(1);
     });
 
+    it("tracks local deprecation until its status is synced", () => {
+      const memory = store.store({
+        orgId: "test-org",
+        repoId: "test-repo",
+        memoryType: "episodic",
+        text: "deprecated after initial sync",
+        visibility: "repo",
+      });
+
+      store.markAsPushed(memory.id, memory.version);
+      expect(store.getDeprecatedMemoriesToSync("test-org", "test-repo")).toEqual([]);
+
+      store.deprecate(memory.id, "outdated");
+
+      const deprecated = store.getDeprecatedMemoriesToSync("test-org", "test-repo");
+      expect(deprecated).toHaveLength(1);
+      expect(deprecated[0].id).toBe(memory.id);
+      expect(deprecated[0].status).toBe("deprecated");
+      expect(deprecated[0].version).toBe(memory.version + 1);
+      expect(deprecated[0].sourceRefs).toMatchObject({ deprecation_reason: "outdated" });
+
+      store.markStatusSynced(memory.id);
+
+      expect(store.getDeprecatedMemoriesToSync("test-org", "test-repo")).toEqual([]);
+      expect(store.getSyncState(memory.id)?.localVersion).toBe(memory.version + 1);
+    });
+
     it("marks as conflict on version mismatch", () => {
       const memory = store.store({
         orgId: "test-org",

--- a/apps/cli/src/commands/push.ts
+++ b/apps/cli/src/commands/push.ts
@@ -44,9 +44,20 @@ export const pushCommand = new Command("push")
       const allToPush = (opts.all
         ? [...pendingPush, ...untrackedToPush.map((memory) => ({ memory, syncState: store.getSyncState(memory.id)! }))]
         : pendingPush
-      ).filter(({ memory }) => memory.status !== "deprecated");
+      ).filter(({ memory, syncState }) => {
+        if (memory.status === "deprecated") return false;
+        if (
+          memory.status === "superseded" &&
+          (syncState.remoteVersion !== undefined || syncState.lastPushedAt || syncState.lastPulledAt)
+        ) {
+          return false;
+        }
+        return true;
+      });
 
-      const supersededToSync = store.getSupersededMemoriesToSync(orgId, repoId);
+      const supersededToSync = store
+        .getSupersededMemoriesToSync(orgId, repoId)
+        .filter(({ memory }) => memory.visibility === "repo" || opts.force);
       const deprecatedToSync = store
         .getDeprecatedMemoriesToSync(orgId, repoId)
         .filter((memory) => memory.visibility === "repo" || opts.force);
@@ -96,6 +107,14 @@ export const pushCommand = new Command("push")
           const fullMemory = store.getById(memory.id);
           if (!fullMemory) continue;
 
+          if (
+            fullMemory.version !== memory.version ||
+            fullMemory.status !== memory.status
+          ) {
+            logger.info(`  ${memory.id.slice(0, 8)}... changed locally before push; update remains pending`);
+            continue;
+          }
+
           if (fullMemory.visibility !== "repo" && !opts.force) {
             logger.info(`  Skipping ${memory.id.slice(0, 8)}... (private memory, use --force to push anyway)`);
             continue;
@@ -117,10 +136,13 @@ export const pushCommand = new Command("push")
             authorName: fullMemory.authorName,
           });
 
-          store.markAsPushed(memory.id, fullMemory.version);
-          pushed++;
-          logger.progress(pushed + errors, allToPush.length, "memories");
-          logger.debug(`pushed ${memory.id.slice(0, 8)}...`);
+          if (store.markAsPushed(memory.id, fullMemory.version, fullMemory.version)) {
+            pushed++;
+            logger.progress(pushed + errors, allToPush.length, "memories");
+            logger.debug(`pushed ${memory.id.slice(0, 8)}...`);
+          } else {
+            logger.info(`  ${memory.id.slice(0, 8)}... changed locally during push; update remains pending`);
+          }
         } catch (err) {
           errors++;
           const errorMsg = err instanceof Error ? err.message : String(err);

--- a/apps/cli/src/commands/push.ts
+++ b/apps/cli/src/commands/push.ts
@@ -35,19 +35,23 @@ export const pushCommand = new Command("push")
 
       const pendingPush = store.getPendingPush();
       const untracked = opts.all ? store.getUntrackedMemories(orgId, repoId) : [];
-      
+
       for (const memory of untracked) {
         store.initSyncStateForMemory(memory.id);
       }
-      
-      const allToPush = opts.all 
-        ? [...pendingPush, ...untracked.map(m => ({ memory: m, syncState: store.getSyncState(m.id)! }))]
-        : pendingPush;
+
+      const allToPush = (opts.all
+        ? [...pendingPush, ...untracked.map((memory) => ({ memory, syncState: store.getSyncState(memory.id)! }))]
+        : pendingPush
+      ).filter(({ memory }) => memory.status !== "deprecated");
 
       const supersededToSync = store.getSupersededMemoriesToSync(orgId, repoId);
+      const deprecatedToSync = store
+        .getDeprecatedMemoriesToSync(orgId, repoId)
+        .filter((memory) => memory.visibility === "repo" || opts.force);
       const linksToSync = store.getLinksToSync(orgId, repoId);
 
-      if (allToPush.length === 0 && supersededToSync.length === 0 && linksToSync.length === 0) {
+      if (allToPush.length === 0 && supersededToSync.length === 0 && deprecatedToSync.length === 0 && linksToSync.length === 0) {
         logger.info("Everything up-to-date");
         return;
       }
@@ -67,13 +71,19 @@ export const pushCommand = new Command("push")
             logger.info(`  ${memory.id.slice(0, 8)}... -> superseded by ${newId.slice(0, 8)}...`);
           }
         }
+        if (deprecatedToSync.length > 0) {
+          logger.info("\nWould sync deprecated status:");
+          for (const memory of deprecatedToSync) {
+            logger.info(`  ${memory.id.slice(0, 8)}... -> deprecated`);
+          }
+        }
         if (linksToSync.length > 0) {
           logger.info("\nWould sync links:");
           for (const { link } of linksToSync) {
             logger.info(`  ${link.sourceId.slice(0, 8)}... -> ${link.targetId.slice(0, 8)}... (${link.linkType})`);
           }
         }
-        logger.info(`\nTotal: ${allToPush.length} memories, ${supersededToSync.length} status updates, ${linksToSync.length} links`);
+        logger.info(`\nTotal: ${allToPush.length} memories, ${supersededToSync.length + deprecatedToSync.length} status updates, ${linksToSync.length} links`);
         return;
       }
 
@@ -143,6 +153,26 @@ export const pushCommand = new Command("push")
         }
       }
 
+      let deprecatedSynced = 0;
+
+      for (const memory of deprecatedToSync) {
+        try {
+          const reason = typeof memory.sourceRefs?.deprecation_reason === "string"
+            ? memory.sourceRefs.deprecation_reason
+            : undefined;
+          await client.deprecate(memory.id, reason);
+          store.markStatusSynced(memory.id);
+          deprecatedSynced++;
+          logger.info(`  ${memory.id.slice(0, 8)}... marked as deprecated on remote`);
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          if (!errorMsg.includes("404")) {
+            errors++;
+            logger.error(`  ${memory.id.slice(0, 8)}... failed to sync deprecated status: ${errorMsg}`);
+          }
+        }
+      }
+
       let linksSynced = 0;
 
       for (const { link } of linksToSync) {
@@ -166,6 +196,9 @@ export const pushCommand = new Command("push")
       }
       if (supersededSynced > 0) {
         logger.info(`${supersededSynced} memory(s) marked as superseded on remote`);
+      }
+      if (deprecatedSynced > 0) {
+        logger.info(`${deprecatedSynced} memory(s) marked as deprecated on remote`);
       }
       if (linksSynced > 0) {
         logger.info(`${linksSynced} link(s) synced`);

--- a/apps/cli/src/commands/push.ts
+++ b/apps/cli/src/commands/push.ts
@@ -35,13 +35,14 @@ export const pushCommand = new Command("push")
 
       const pendingPush = store.getPendingPush();
       const untracked = opts.all ? store.getUntrackedMemories(orgId, repoId) : [];
+      const untrackedToPush = untracked.filter((memory) => memory.status !== "deprecated");
 
-      for (const memory of untracked) {
+      for (const memory of untrackedToPush) {
         store.initSyncStateForMemory(memory.id);
       }
 
       const allToPush = (opts.all
-        ? [...pendingPush, ...untracked.map((memory) => ({ memory, syncState: store.getSyncState(memory.id)! }))]
+        ? [...pendingPush, ...untrackedToPush.map((memory) => ({ memory, syncState: store.getSyncState(memory.id)! }))]
         : pendingPush
       ).filter(({ memory }) => memory.status !== "deprecated");
 
@@ -141,9 +142,12 @@ export const pushCommand = new Command("push")
       for (const { memory, newId } of supersededToSync) {
         try {
           await client.supersede(memory.id, newId);
-          store.markStatusSynced(memory.id);
-          supersededSynced++;
-          logger.info(`  ${memory.id.slice(0, 8)}... marked as superseded on remote`);
+          if (store.markStatusSynced(memory.id, memory.version)) {
+            supersededSynced++;
+            logger.info(`  ${memory.id.slice(0, 8)}... marked as superseded on remote`);
+          } else {
+            logger.info(`  ${memory.id.slice(0, 8)}... changed locally during push; update remains pending`);
+          }
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : String(err);
           if (!errorMsg.includes("404")) {
@@ -161,9 +165,12 @@ export const pushCommand = new Command("push")
             ? memory.sourceRefs.deprecation_reason
             : undefined;
           await client.deprecate(memory.id, reason);
-          store.markStatusSynced(memory.id);
-          deprecatedSynced++;
-          logger.info(`  ${memory.id.slice(0, 8)}... marked as deprecated on remote`);
+          if (store.markStatusSynced(memory.id, memory.version)) {
+            deprecatedSynced++;
+            logger.info(`  ${memory.id.slice(0, 8)}... marked as deprecated on remote`);
+          } else {
+            logger.info(`  ${memory.id.slice(0, 8)}... changed locally during push; update remains pending`);
+          }
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : String(err);
           if (!errorMsg.includes("404")) {

--- a/packages/db/src/local.ts
+++ b/packages/db/src/local.ts
@@ -772,7 +772,7 @@ export class LocalStore {
     const now = new Date().toISOString();
     const result = this.db
       .prepare(
-        "UPDATE memories SET status = 'deprecated', updated_at = ? WHERE id = ?",
+        "UPDATE memories SET status = 'deprecated', version = version + 1, updated_at = ? WHERE id = ?",
       )
       .run(now, id);
 
@@ -1641,6 +1641,26 @@ export class LocalStore {
     }));
   }
 
+  getDeprecatedMemoriesToSync(orgId: string, repoId: string): Memory[] {
+    const rows = this.db
+      .prepare(`
+        SELECT m.*
+        FROM memories m
+        LEFT JOIN sync_state s ON s.memory_id = m.id
+        WHERE m.org_id = ?
+          AND m.repo_id = ?
+          AND m.status = 'deprecated'
+          AND (
+            s.memory_id IS NULL
+            OR s.sync_status = 'pending_push'
+            OR (s.sync_status = 'synced' AND (s.last_pushed_at IS NULL OR s.last_pushed_at < m.updated_at))
+          )
+      `)
+      .all(orgId, repoId) as Array<Record<string, unknown>>;
+
+    return rows.map(rowToMemory);
+  }
+
   getLinksToSync(orgId: string, repoId: string): Array<{ link: MemoryLink; sourceMemoryId: string; targetMemoryId: string }> {
     const rows = this.db
       .prepare(`
@@ -1671,8 +1691,14 @@ export class LocalStore {
   markStatusSynced(memoryId: string): void {
     const now = new Date().toISOString();
     this.db
-      .prepare(`UPDATE sync_state SET last_pushed_at = ? WHERE memory_id = ?`)
-      .run(now, memoryId);
+      .prepare(`
+        UPDATE sync_state
+        SET last_pushed_at = ?,
+            local_version = (SELECT version FROM memories WHERE id = ?),
+            sync_status = 'synced'
+        WHERE memory_id = ?
+      `)
+      .run(now, memoryId, memoryId);
   }
 
   unconsolidate(consolidationId: string): {

--- a/packages/db/src/local.ts
+++ b/packages/db/src/local.ts
@@ -787,6 +787,21 @@ export class LocalStore {
       }
     }
 
+    if (result.changes > 0) {
+      this.db
+        .prepare(`
+          UPDATE sync_state
+          SET local_version = (SELECT version FROM memories WHERE id = ?),
+              sync_status = CASE
+                WHEN remote_version IS NULL AND last_pushed_at IS NULL AND last_pulled_at IS NULL
+                  THEN 'synced'
+                ELSE 'pending_push'
+              END
+          WHERE memory_id = ?
+        `)
+        .run(id, id);
+    }
+
     return result.changes > 0;
   }
 
@@ -1650,9 +1665,9 @@ export class LocalStore {
         WHERE m.org_id = ?
           AND m.repo_id = ?
           AND m.status = 'deprecated'
+          AND (s.remote_version IS NOT NULL OR s.last_pushed_at IS NOT NULL OR s.last_pulled_at IS NOT NULL)
           AND (
-            s.memory_id IS NULL
-            OR s.sync_status = 'pending_push'
+            s.sync_status = 'pending_push'
             OR (s.sync_status = 'synced' AND (s.last_pushed_at IS NULL OR s.last_pushed_at < m.updated_at))
           )
       `)

--- a/packages/db/src/local.ts
+++ b/packages/db/src/local.ts
@@ -806,13 +806,34 @@ export class LocalStore {
   }
 
   supersede(oldId: string, newId: string): boolean {
-    const now = new Date().toISOString();
-    const result = this.db
-      .prepare(
-        "UPDATE memories SET status = 'superseded', supersedes_id = ?, updated_at = ? WHERE id = ?",
-      )
-      .run(newId, now, oldId);
-    return result.changes > 0;
+    const transaction = this.db.transaction(() => {
+      const memory = this.getById(oldId);
+      if (!memory) return false;
+
+      const now = new Date().toISOString();
+      const result = this.db
+        .prepare(`
+          UPDATE memories
+          SET status = 'superseded', supersedes_id = ?, version = version + 1, updated_at = ?
+          WHERE id = ?
+        `)
+        .run(newId, now, oldId);
+
+      if (result.changes > 0) {
+        this.db
+          .prepare(`
+            UPDATE sync_state
+            SET local_version = (SELECT version FROM memories WHERE id = ?),
+                sync_status = 'pending_push'
+            WHERE memory_id = ?
+          `)
+          .run(oldId, oldId);
+      }
+
+      return result.changes > 0;
+    });
+
+    return transaction.immediate();
   }
 
   updateVisibility(id: string, visibility: "private" | "repo"): boolean {
@@ -1536,15 +1557,45 @@ export class LocalStore {
       );
   }
 
-  markAsPushed(memoryId: string, remoteVersion: number): void {
-    const now = new Date().toISOString();
-    this.db
-      .prepare(`
-        UPDATE sync_state 
-        SET sync_status = 'synced', remote_version = ?, last_pushed_at = ?
-        WHERE memory_id = ?
-      `)
-      .run(remoteVersion, now, memoryId);
+  markAsPushed(memoryId: string, remoteVersion: number, expectedVersion?: number): boolean {
+    const transaction = this.db.transaction(() => {
+      const now = new Date().toISOString();
+      if (expectedVersion === undefined) {
+        const result = this.db
+          .prepare(`
+            UPDATE sync_state
+            SET sync_status = 'synced', remote_version = ?, last_pushed_at = ?
+            WHERE memory_id = ?
+          `)
+          .run(remoteVersion, now, memoryId);
+        return result.changes > 0;
+      }
+
+      const result = this.db
+        .prepare(`
+          UPDATE sync_state
+          SET remote_version = MAX(COALESCE(remote_version, 0), ?),
+              last_pushed_at = ?,
+              sync_status = CASE
+                WHEN local_version = ?
+                  AND sync_status = 'pending_push'
+                  AND EXISTS (
+                    SELECT 1 FROM memories WHERE id = ? AND version = ?
+                  )
+                  THEN 'synced'
+                WHEN sync_status IN ('conflict', 'pending_pull') THEN sync_status
+                ELSE 'pending_push'
+              END
+          WHERE memory_id = ?
+        `)
+        .run(remoteVersion, now, expectedVersion, memoryId, expectedVersion, memoryId);
+      if (result.changes === 0) return false;
+
+      const state = this.getSyncState(memoryId);
+      return state?.syncStatus === "synced" && state.localVersion === expectedVersion;
+    });
+
+    return transaction.immediate();
   }
 
   markAsPulled(memoryId: string, localVersion: number): void {
@@ -1715,11 +1766,13 @@ export class LocalStore {
             local_version = ?,
             sync_status = 'synced'
         WHERE memory_id = ?
+          AND local_version = ?
+          AND sync_status IN ('pending_push', 'synced')
           AND EXISTS (
             SELECT 1 FROM memories WHERE id = ? AND version = ?
           )
       `)
-      .run(now, expectedVersion, memoryId, memoryId, expectedVersion);
+      .run(now, expectedVersion, memoryId, expectedVersion, memoryId, expectedVersion);
     return result.changes > 0;
   }
 

--- a/packages/db/src/local.ts
+++ b/packages/db/src/local.ts
@@ -769,40 +769,40 @@ export class LocalStore {
   }
 
   deprecate(id: string, reason?: string): boolean {
-    const now = new Date().toISOString();
-    const result = this.db
-      .prepare(
-        "UPDATE memories SET status = 'deprecated', version = version + 1, updated_at = ? WHERE id = ?",
-      )
-      .run(now, id);
-
-    if (reason && result.changes > 0) {
+    const transaction = this.db.transaction(() => {
       const mem = this.getById(id);
-      if (mem) {
-        const refs = mem.sourceRefs ?? {};
-        (refs as Record<string, unknown>).deprecation_reason = reason;
-        this.db
-          .prepare("UPDATE memories SET source_refs = ? WHERE id = ?")
-          .run(JSON.stringify(refs), id);
-      }
-    }
+      if (!mem) return false;
 
-    if (result.changes > 0) {
-      this.db
+      const now = new Date().toISOString();
+      const refs = { ...(mem.sourceRefs ?? {}) };
+      if (reason) refs.deprecation_reason = reason;
+      const result = this.db
         .prepare(`
-          UPDATE sync_state
-          SET local_version = (SELECT version FROM memories WHERE id = ?),
-              sync_status = CASE
-                WHEN remote_version IS NULL AND last_pushed_at IS NULL AND last_pulled_at IS NULL
-                  THEN 'synced'
-                ELSE 'pending_push'
-              END
-          WHERE memory_id = ?
+          UPDATE memories
+          SET status = 'deprecated', source_refs = ?, version = version + 1, updated_at = ?
+          WHERE id = ?
         `)
-        .run(id, id);
-    }
+        .run(Object.keys(refs).length > 0 ? JSON.stringify(refs) : null, now, id);
 
-    return result.changes > 0;
+      if (result.changes > 0) {
+        this.db
+          .prepare(`
+            UPDATE sync_state
+            SET local_version = (SELECT version FROM memories WHERE id = ?),
+                sync_status = CASE
+                  WHEN remote_version IS NULL AND last_pushed_at IS NULL AND last_pulled_at IS NULL
+                    THEN 'synced'
+                  ELSE 'pending_push'
+                END
+            WHERE memory_id = ?
+          `)
+          .run(id, id);
+      }
+
+      return result.changes > 0;
+    });
+
+    return transaction.immediate();
   }
 
   supersede(oldId: string, newId: string): boolean {
@@ -1668,7 +1668,10 @@ export class LocalStore {
           AND (s.remote_version IS NOT NULL OR s.last_pushed_at IS NOT NULL OR s.last_pulled_at IS NOT NULL)
           AND (
             s.sync_status = 'pending_push'
-            OR (s.sync_status = 'synced' AND (s.last_pushed_at IS NULL OR s.last_pushed_at < m.updated_at))
+            OR (
+              s.sync_status = 'synced'
+              AND MAX(COALESCE(s.last_pushed_at, ''), COALESCE(s.last_pulled_at, '')) < m.updated_at
+            )
           )
       `)
       .all(orgId, repoId) as Array<Record<string, unknown>>;
@@ -1703,17 +1706,21 @@ export class LocalStore {
       .run(linkId, now);
   }
 
-  markStatusSynced(memoryId: string): void {
+  markStatusSynced(memoryId: string, expectedVersion: number): boolean {
     const now = new Date().toISOString();
-    this.db
+    const result = this.db
       .prepare(`
         UPDATE sync_state
         SET last_pushed_at = ?,
-            local_version = (SELECT version FROM memories WHERE id = ?),
+            local_version = ?,
             sync_status = 'synced'
         WHERE memory_id = ?
+          AND EXISTS (
+            SELECT 1 FROM memories WHERE id = ? AND version = ?
+          )
       `)
-      .run(now, memoryId, memoryId);
+      .run(now, expectedVersion, memoryId, memoryId, expectedVersion);
+    return result.changes > 0;
   }
 
   unconsolidate(consolidationId: string): {


### PR DESCRIPTION
## Summary
- track local deprecation and supersede changes as versioned lifecycle updates
- propagate previously synced deprecation and supersede status through `unforgit push`
- prevent stale push acknowledgements from dropping concurrent lifecycle or conflict updates
- keep private lifecycle status local unless `--force` is explicitly used

## Regression coverage
- local deprecation after initial sync
- never-synced and remotely pulled deprecated memories
- deprecation during an in-flight ordinary/status push
- lifecycle changes after push queues are captured
- repeated supersede target changes during an in-flight status push
- conflict-state preservation and private lifecycle handling

## Verification
- Node 24.15.0 / pnpm 10.28.1 frozen install
- Prisma generation
- lint
- 64 test files / 375 tests
- full monorepo build
- CLI smoke
- pnpm audit and production audit: no known vulnerabilities
- website npm audit: 0 vulnerabilities
- `git diff --check`
