### PR TITLE
fix(website): make Docker installs reproducible

### DIFF
--- a/apps/website/Dockerfile
+++ b/apps/website/Dockerfile
@@ -7,8 +7,8 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install
+COPY package.json package-lock.json ./
+RUN npm ci
 
 FROM base AS builder
 WORKDIR /app

--- a/apps/website/src/__tests__/dockerfile-reproducibility.test.ts
+++ b/apps/website/src/__tests__/dockerfile-reproducibility.test.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("website Docker dependency installation", () => {
+  it("installs dependencies from the committed lockfile", () => {
+    const dockerfile = fs.readFileSync(
+      path.resolve("apps/website/Dockerfile"),
+      "utf-8",
+    );
+    const depsStage = dockerfile.slice(
+      dockerfile.indexOf("FROM base AS deps"),
+      dockerfile.indexOf("FROM base AS builder"),
+    );
+
+    expect(depsStage).toContain("COPY package.json package-lock.json ./");
+    expect(depsStage).toContain("RUN npm ci");
+  });
+});


### PR DESCRIPTION
## Summary

- require the website image to install from its committed npm lockfile
- prevent Docker builds from resolving newer dependency versions than local/CI builds

## Reproduction

The v0.11.3 image build used `npm install` after copying only `package.json`, resolving Next.js 15.5.25 while `package-lock.json` pins 15.5.21.

## TDD

- RED: focused contract test failed against the previous Dockerfile
- GREEN: 65 test files / 376 tests pass
- Docker deps-stage build installs Next.js 15.5.21 from the lockfile

## Verification

- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm smoke:cli`
- `pnpm smoke:packed-cli`
- `pnpm audit` and `pnpm audit --prod`: 0 vulnerabilities
- website full/production npm audits: 0 vulnerabilities
- npm registry signatures: 997 verified; attestations: 233 verified
