### PR TITLE
fix(api): prevent cross-repository memory overwrite

### DIFF
--- a/apps/api/src/__tests__/memory.test.ts
+++ b/apps/api/src/__tests__/memory.test.ts
@@ -10,6 +10,8 @@ function buildStore() {
     count: vi.fn(),
     getById: vi.fn(),
     store: vi.fn(),
+    storeWithinScope: vi.fn(),
+    createApiKeyLog: vi.fn().mockResolvedValue(undefined),
     validateApiKey: vi.fn().mockResolvedValue({
       id: "key-id",
       orgId: "org",
@@ -21,6 +23,8 @@ function buildStore() {
     count: ReturnType<typeof vi.fn>;
     getById: ReturnType<typeof vi.fn>;
     store: ReturnType<typeof vi.fn>;
+    storeWithinScope: ReturnType<typeof vi.fn>;
+    createApiKeyLog: ReturnType<typeof vi.fn>;
     validateApiKey: ReturnType<typeof vi.fn>;
   };
 }
@@ -134,6 +138,82 @@ describe("memory routes", () => {
     expect(response.statusCode).toBe(403);
     expect(response.json()).toEqual({ error: "Forbidden" });
     expect(store.store).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("does not let a repository-scoped API key overwrite another repository's memory by ID", async () => {
+    const store = buildStore();
+    store.validateApiKey.mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    });
+    store.storeWithinScope.mockResolvedValue(undefined);
+    const app = await buildMemoryApp(store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/memory",
+      headers: { authorization: "Bearer valid-token" },
+      payload: {
+        id: "3e7dd5df-ff40-4bc1-8419-1e165fe6c2ab",
+        orgId: "org-a",
+        repoId: "repo-a",
+        text: "replacement memory",
+        memoryType: "semantic",
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.storeWithinScope).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "3e7dd5df-ff40-4bc1-8419-1e165fe6c2ab",
+        orgId: "org-a",
+        repoId: "repo-a",
+      }),
+      { orgId: "org-a", repoId: "repo-a" },
+    );
+    expect(store.store).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("allows an API key to update a memory within its repository scope", async () => {
+    const store = buildStore();
+    store.validateApiKey.mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    });
+    store.storeWithinScope.mockResolvedValue({
+      id: "3e7dd5df-ff40-4bc1-8419-1e165fe6c2ab",
+      orgId: "org-a",
+      repoId: "repo-a",
+      text: "replacement memory",
+    });
+    const app = await buildMemoryApp(store);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/memory",
+      headers: { authorization: "Bearer valid-token" },
+      payload: {
+        id: "3e7dd5df-ff40-4bc1-8419-1e165fe6c2ab",
+        orgId: "org-a",
+        repoId: "repo-a",
+        text: "replacement memory",
+        memoryType: "semantic",
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json()).toEqual({
+      id: "3e7dd5df-ff40-4bc1-8419-1e165fe6c2ab",
+    });
 
     await app.close();
   });

--- a/apps/api/src/routes/memory.ts
+++ b/apps/api/src/routes/memory.ts
@@ -111,7 +111,13 @@ export async function memoryRoutes(
       return reply.status(403).send({ error: "Forbidden" });
     }
 
-    const memory = await store.store(applyLifecycleDefaults(parsed.data));
+    const memory = await store.storeWithinScope(
+      applyLifecycleDefaults(parsed.data),
+      { orgId: apiKey.orgId, repoId: apiKey.repoId },
+    );
+    if (!memory) {
+      return reply.status(403).send({ error: "Forbidden" });
+    }
     scheduleLifecycle?.(parsed.data.orgId, parsed.data.repoId);
 
     if (request.apiKey) {

--- a/packages/db/src/__tests__/remote-store-scope.test.ts
+++ b/packages/db/src/__tests__/remote-store-scope.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import { RemoteStore } from "../remote.js";
+
+const id = "3e7dd5df-ff40-4bc1-8419-1e165fe6c2ab";
+const row = {
+  id,
+  orgId: "org-a",
+  repoId: "repo-a",
+  scopeType: "repo",
+  memoryType: "semantic",
+  visibility: "repo",
+  status: "active",
+  text: "replacement memory",
+  summary: null,
+  tags: [],
+  sourceRefs: null,
+  confidence: null,
+  ttlSeconds: null,
+  supersedesId: null,
+  version: 1,
+  deletedAt: null,
+  deletedBy: null,
+  createdAt: new Date("2026-09-09T00:00:00.000Z"),
+  updatedAt: new Date("2026-09-09T00:00:00.000Z"),
+};
+
+function buildStore(queryResult: Array<{ id: string }>) {
+  const prisma = {
+    $queryRaw: vi.fn().mockResolvedValue(queryResult),
+    memory: {
+      findUnique: vi.fn().mockResolvedValue(row),
+    },
+  };
+  const store = new RemoteStore("postgresql://localhost/unforgit", {
+    autoEmbeddingEnabled: false,
+  });
+  Object.defineProperty(store, "prisma", { value: prisma });
+  return { prisma, store };
+}
+
+const input = {
+  id,
+  orgId: "org-a",
+  repoId: "repo-a",
+  memoryType: "semantic" as const,
+  text: "replacement memory",
+};
+
+describe("RemoteStore.storeWithinScope", () => {
+  it("uses the regular create path when the caller does not provide an ID", async () => {
+    const { prisma, store } = buildStore([{ id }]);
+    const storeSpy = vi.spyOn(store, "store").mockResolvedValue(
+      row as unknown as Awaited<ReturnType<RemoteStore["store"]>>,
+    );
+    const inputWithoutId = { ...input, id: undefined };
+
+    await expect(
+      store.storeWithinScope(inputWithoutId, {
+        orgId: "org-a",
+        repoId: "repo-a",
+      }),
+    ).resolves.toMatchObject({ id });
+    expect(storeSpy).toHaveBeenCalledWith(inputWithoutId);
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the payload is outside the authorized scope", async () => {
+    const { prisma, store } = buildStore([{ id }]);
+
+    await expect(
+      store.storeWithinScope(input, { orgId: "org-b", repoId: null }),
+    ).resolves.toBeUndefined();
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when an explicit ID collides outside the authorized scope", async () => {
+    const { prisma, store } = buildStore([]);
+
+    await expect(
+      store.storeWithinScope(input, { orgId: "org-a", repoId: "repo-a" }),
+    ).resolves.toBeUndefined();
+    expect(prisma.memory.findUnique).not.toHaveBeenCalled();
+
+    const query = prisma.$queryRaw.mock.calls[0][0] as {
+      text: string;
+      values: unknown[];
+    };
+    expect(query.text).toContain('ON CONFLICT ("id") DO UPDATE');
+    expect(query.text).toContain('LOWER("memories"."org_id")');
+    expect(query.text).toContain('LOWER("memories"."repo_id")');
+    expect(query.text).toContain('RETURNING "id"');
+    expect(query.values).toContain("org-a");
+    expect(query.values).toContain("repo-a");
+  });
+
+  it("returns the atomically stored memory when the scope guard succeeds", async () => {
+    const { prisma, store } = buildStore([{ id }]);
+
+    await expect(
+      store.storeWithinScope(input, { orgId: "org-a", repoId: "repo-a" }),
+    ).resolves.toMatchObject({
+      id,
+      orgId: "org-a",
+      repoId: "repo-a",
+      text: "replacement memory",
+    });
+    expect(prisma.memory.findUnique).toHaveBeenCalledWith({ where: { id } });
+  });
+
+  it("allows an organization-wide key to update another repository in its organization", async () => {
+    const { prisma, store } = buildStore([{ id }]);
+
+    await expect(
+      store.storeWithinScope(input, { orgId: "org-a", repoId: null }),
+    ).resolves.toMatchObject({ id });
+
+    const query = prisma.$queryRaw.mock.calls[0][0] as {
+      text: string;
+      values: unknown[];
+    };
+    expect(query.text).toContain("::text IS NULL");
+    expect(query.values).toContain(null);
+  });
+});

--- a/packages/db/src/remote.ts
+++ b/packages/db/src/remote.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "./generated/prisma/client.js";
+import { Prisma, PrismaClient } from "./generated/prisma/client.js";
 import { PrismaPg } from "@prisma/adapter-pg";
 import type {
   Memory,
@@ -103,6 +103,11 @@ export interface RemoteStoreOptions {
   autoEmbeddingEnabled?: boolean;
 }
 
+export interface StoreAuthorizationScope {
+  orgId: string;
+  repoId: string | null;
+}
+
 export class RemoteStore {
   private prisma: PrismaClient;
   private autoEmbeddingEnabled: boolean;
@@ -169,6 +174,105 @@ export class RemoteStore {
       memory = prismaRowToMemory(row as unknown as Record<string, unknown>);
     }
 
+    if (this.autoEmbeddingEnabled && isOpenAIConfigured()) {
+      this.generateAndStoreEmbedding(memory.id, memory.text).catch((err) => {
+        console.error(`Auto-embedding failed for ${memory.id}:`, err);
+      });
+    }
+
+    return memory;
+  }
+
+  async storeWithinScope(
+    input: CreateMemoryInput,
+    authorizedScope: StoreAuthorizationScope,
+  ): Promise<Memory | undefined> {
+    const normalizedOrgId = input.orgId.toLowerCase();
+    const normalizedRepoId = input.repoId.toLowerCase();
+    const normalizedAuthorizedOrgId = authorizedScope.orgId.toLowerCase();
+    const normalizedAuthorizedRepoId = authorizedScope.repoId?.toLowerCase() ?? null;
+
+    if (
+      normalizedAuthorizedOrgId !== normalizedOrgId ||
+      (normalizedAuthorizedRepoId !== null &&
+        normalizedAuthorizedRepoId !== normalizedRepoId)
+    ) {
+      return undefined;
+    }
+
+    if (!input.id) {
+      return this.store(input);
+    }
+
+    const resolvedInput = applyLifecycleDefaults(input);
+    const visibility =
+      resolvedInput.visibility === "auto" || !resolvedInput.visibility
+        ? "repo"
+        : resolvedInput.visibility;
+    const sourceRefs = resolvedInput.sourceRefs === undefined
+      ? null
+      : JSON.stringify(resolvedInput.sourceRefs);
+
+    const stored = await this.prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+      INSERT INTO "memories" (
+        "id",
+        "org_id",
+        "repo_id",
+        "memory_type",
+        "visibility",
+        "text",
+        "summary",
+        "tags",
+        "source_refs",
+        "confidence",
+        "ttl_seconds",
+        "updated_at"
+      ) VALUES (
+        ${resolvedInput.id}::uuid,
+        ${normalizedOrgId},
+        ${normalizedRepoId},
+        ${resolvedInput.memoryType},
+        ${visibility},
+        ${resolvedInput.text},
+        ${resolvedInput.summary ?? null},
+        ${resolvedInput.tags ?? []}::text[],
+        ${sourceRefs}::jsonb,
+        ${resolvedInput.confidence ?? null},
+        ${resolvedInput.ttlSeconds ?? null},
+        CURRENT_TIMESTAMP
+      )
+      ON CONFLICT ("id") DO UPDATE SET
+        "org_id" = EXCLUDED."org_id",
+        "repo_id" = EXCLUDED."repo_id",
+        "memory_type" = EXCLUDED."memory_type",
+        "visibility" = EXCLUDED."visibility",
+        "text" = EXCLUDED."text",
+        "summary" = COALESCE(EXCLUDED."summary", "memories"."summary"),
+        "tags" = EXCLUDED."tags",
+        "source_refs" = COALESCE(EXCLUDED."source_refs", "memories"."source_refs"),
+        "confidence" = COALESCE(EXCLUDED."confidence", "memories"."confidence"),
+        "ttl_seconds" = COALESCE(EXCLUDED."ttl_seconds", "memories"."ttl_seconds"),
+        "updated_at" = CURRENT_TIMESTAMP
+      WHERE LOWER("memories"."org_id") = ${normalizedAuthorizedOrgId}
+        AND (
+          ${normalizedAuthorizedRepoId}::text IS NULL
+          OR LOWER("memories"."repo_id") = ${normalizedAuthorizedRepoId}
+        )
+      RETURNING "id"
+    `);
+
+    if (stored.length === 0) {
+      return undefined;
+    }
+
+    const row = await this.prisma.memory.findUnique({
+      where: { id: resolvedInput.id },
+    });
+    if (!row) {
+      throw new Error("Stored memory could not be loaded");
+    }
+
+    const memory = prismaRowToMemory(row as unknown as Record<string, unknown>);
     if (this.autoEmbeddingEnabled && isOpenAIConfigured()) {
       this.generateAndStoreEmbedding(memory.id, memory.text).catch((err) => {
         console.error(`Auto-embedding failed for ${memory.id}:`, err);


### PR DESCRIPTION
## Summary
- authorize caller-supplied memory IDs inside the PostgreSQL write itself
- reject cross-repository and cross-organization ID collisions without mutating the existing memory
- keep normal creates, same-scope updates, and organization-wide keys working
- cover route behavior and the atomic `ON CONFLICT ... WHERE` scope guard

## Security impact
Repository-scoped API keys could previously move and overwrite another repository's memory by submitting its UUID to `POST /v1/memory`. The guarded upsert also closes the cross-instance TOCTOU race between an ownership lookup and the write.

## Verification
- RED: regression reproduced the endpoint failure before the fix
- focused tests: 12 passed
- full tests: 66 files / 383 tests passed
- lint: passed
- build: passed
- CLI smoke: passed
- root pnpm audit: 0 vulnerabilities
- website npm audit: 0 vulnerabilities
- live PostgreSQL check: sequential foreign collision blocked; two-client concurrent collision produced exactly one winner and preserved its scope
- Docker images rebuilt; local API health and website/admin HTTP checks returned 200
