### PR TITLE
fix(db): make remote reset atomic

### DIFF
--- a/packages/db/src/__tests__/remote-reset.test.ts
+++ b/packages/db/src/__tests__/remote-reset.test.ts
@@ -54,6 +54,30 @@ describe("RemoteStore.resetAll", () => {
     );
   });
 
+  it("retries serializable transaction conflicts", async () => {
+    const store = new RemoteStore("postgresql://user:***@localhost:5432/test");
+    const prisma = {
+      memory: { deleteMany: vi.fn().mockResolvedValue({ count: 2 }) },
+      memoryEmbedding: { deleteMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      memoryUsage: { deleteMany: vi.fn().mockResolvedValue({ count: 3 }) },
+      memoryLink: { deleteMany: vi.fn().mockResolvedValue({ count: 4 }) },
+      tombstone: { deleteMany: vi.fn().mockResolvedValue({ count: 1 }) },
+      $transaction: vi.fn()
+        .mockRejectedValueOnce({ code: "P2034", message: "write conflict" })
+        .mockImplementationOnce(async (operations: Array<Promise<unknown>>) => Promise.all(operations)),
+      $disconnect: vi.fn(),
+    };
+
+    (store as unknown as { prisma: typeof prisma }).prisma = prisma;
+
+    await expect(store.resetAll("org", "repo")).resolves.toEqual({
+      memoriesDeleted: 2,
+      linksDeleted: 4,
+      embeddingsDeleted: 1,
+    });
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+  });
+
   it("ignores missing embeddings and usage tables for older schemas", async () => {
     const store = new RemoteStore("postgresql://user:pass@localhost:5432/test");
 

--- a/packages/db/src/__tests__/remote-reset.test.ts
+++ b/packages/db/src/__tests__/remote-reset.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { RemoteStore } from "../remote.js";
 
 describe("RemoteStore.resetAll", () => {
-  it("keeps every delete in one transaction", async () => {
+  it("scopes every delete inside one serializable transaction", async () => {
     const store = new RemoteStore("postgresql://user:***@localhost:5432/test");
     const embeddingDelete = Promise.resolve({ count: 1 });
     const usageDelete = Promise.resolve({ count: 1 });
@@ -13,7 +13,6 @@ describe("RemoteStore.resetAll", () => {
 
     const prisma = {
       memory: {
-        findMany: vi.fn().mockResolvedValue([{ id: "m1" }]),
         deleteMany: vi.fn().mockReturnValue(memoryDelete),
       },
       memoryEmbedding: {
@@ -35,13 +34,24 @@ describe("RemoteStore.resetAll", () => {
     (store as unknown as { prisma: typeof prisma }).prisma = prisma;
 
     await expect(store.resetAll("org", "repo")).rejects.toThrow("transaction failed");
-    expect(prisma.$transaction).toHaveBeenCalledWith([
-      embeddingDelete,
-      usageDelete,
-      linkDelete,
-      tombstoneDelete,
-      memoryDelete,
-    ]);
+    expect(prisma.memoryEmbedding.deleteMany).toHaveBeenCalledWith({
+      where: { memory: { is: { orgId: "org", repoId: "repo" } } },
+    });
+    expect(prisma.memoryUsage.deleteMany).toHaveBeenCalledWith({
+      where: { memory: { is: { orgId: "org", repoId: "repo" } } },
+    });
+    expect(prisma.memoryLink.deleteMany).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { source: { is: { orgId: "org", repoId: "repo" } } },
+          { target: { is: { orgId: "org", repoId: "repo" } } },
+        ],
+      },
+    });
+    expect(prisma.$transaction).toHaveBeenCalledWith(
+      [embeddingDelete, usageDelete, linkDelete, tombstoneDelete, memoryDelete],
+      { isolationLevel: "Serializable" },
+    );
   });
 
   it("ignores missing embeddings and usage tables for older schemas", async () => {
@@ -49,7 +59,6 @@ describe("RemoteStore.resetAll", () => {
 
     const prisma = {
       memory: {
-        findMany: vi.fn().mockResolvedValue([{ id: "m1" }, { id: "m2" }]),
         deleteMany: vi.fn().mockResolvedValue({ count: 2 }),
       },
       memoryEmbedding: {
@@ -81,5 +90,6 @@ describe("RemoteStore.resetAll", () => {
       linksDeleted: 3,
       embeddingsDeleted: 0,
     });
+    expect(prisma.$transaction).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/db/src/__tests__/remote-reset.test.ts
+++ b/packages/db/src/__tests__/remote-reset.test.ts
@@ -2,6 +2,48 @@ import { describe, it, expect, vi } from "vitest";
 import { RemoteStore } from "../remote.js";
 
 describe("RemoteStore.resetAll", () => {
+  it("keeps every delete in one transaction", async () => {
+    const store = new RemoteStore("postgresql://user:***@localhost:5432/test");
+    const embeddingDelete = Promise.resolve({ count: 1 });
+    const usageDelete = Promise.resolve({ count: 1 });
+    const linkDelete = Promise.resolve({ count: 1 });
+    const tombstoneDelete = Promise.resolve({ count: 1 });
+    const memoryDelete = Promise.resolve({ count: 1 });
+    const transactionError = new Error("transaction failed");
+
+    const prisma = {
+      memory: {
+        findMany: vi.fn().mockResolvedValue([{ id: "m1" }]),
+        deleteMany: vi.fn().mockReturnValue(memoryDelete),
+      },
+      memoryEmbedding: {
+        deleteMany: vi.fn().mockReturnValue(embeddingDelete),
+      },
+      memoryUsage: {
+        deleteMany: vi.fn().mockReturnValue(usageDelete),
+      },
+      memoryLink: {
+        deleteMany: vi.fn().mockReturnValue(linkDelete),
+      },
+      tombstone: {
+        deleteMany: vi.fn().mockReturnValue(tombstoneDelete),
+      },
+      $transaction: vi.fn().mockRejectedValue(transactionError),
+      $disconnect: vi.fn(),
+    };
+
+    (store as unknown as { prisma: typeof prisma }).prisma = prisma;
+
+    await expect(store.resetAll("org", "repo")).rejects.toThrow("transaction failed");
+    expect(prisma.$transaction).toHaveBeenCalledWith([
+      embeddingDelete,
+      usageDelete,
+      linkDelete,
+      tombstoneDelete,
+      memoryDelete,
+    ]);
+  });
+
   it("ignores missing embeddings and usage tables for older schemas", async () => {
     const store = new RemoteStore("postgresql://user:pass@localhost:5432/test");
 

--- a/packages/db/src/remote.ts
+++ b/packages/db/src/remote.ts
@@ -1595,16 +1595,6 @@ export class RemoteStore {
     orgId: string,
     repoId: string,
   ): Promise<{ memoriesDeleted: number; linksDeleted: number; embeddingsDeleted: number }> {
-    const memories = await this.prisma.memory.findMany({
-      where: { orgId, repoId },
-      select: { id: true },
-    });
-    const memoryIds = memories.map((m) => m.id);
-
-    if (memoryIds.length === 0) {
-      return { memoriesDeleted: 0, linksDeleted: 0, embeddingsDeleted: 0 };
-    }
-
     let includeEmbeddings = true;
     let includeUsage = true;
 
@@ -1612,23 +1602,30 @@ export class RemoteStore {
       const operations = [
         ...(includeEmbeddings
           ? [this.prisma.memoryEmbedding.deleteMany({
-              where: { memoryId: { in: memoryIds } },
+              where: { memory: { is: { orgId, repoId } } },
             })]
           : []),
         ...(includeUsage
           ? [this.prisma.memoryUsage.deleteMany({
-              where: { memoryId: { in: memoryIds } },
+              where: { memory: { is: { orgId, repoId } } },
             })]
           : []),
         this.prisma.memoryLink.deleteMany({
-          where: { OR: [{ sourceId: { in: memoryIds } }, { targetId: { in: memoryIds } }] },
+          where: {
+            OR: [
+              { source: { is: { orgId, repoId } } },
+              { target: { is: { orgId, repoId } } },
+            ],
+          },
         }),
         this.prisma.tombstone.deleteMany({ where: { orgId, repoId } }),
         this.prisma.memory.deleteMany({ where: { orgId, repoId } }),
       ];
 
       try {
-        const results = await this.prisma.$transaction(operations);
+        const results = await this.prisma.$transaction(operations, {
+          isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+        });
         let resultIndex = 0;
         const embeddingsDeleted = includeEmbeddings ? results[resultIndex++].count : 0;
         if (includeUsage) {

--- a/packages/db/src/remote.ts
+++ b/packages/db/src/remote.ts
@@ -1605,41 +1605,58 @@ export class RemoteStore {
       return { memoriesDeleted: 0, linksDeleted: 0, embeddingsDeleted: 0 };
     }
 
-    let embeddingsDeleted = 0;
-    try {
-      const result = await this.prisma.memoryEmbedding.deleteMany({
-        where: { memoryId: { in: memoryIds } },
-      });
-      embeddingsDeleted = result.count;
-    } catch (error) {
-      if (!isMissingTableError(error, "public.memory_embeddings")) {
+    let includeEmbeddings = true;
+    let includeUsage = true;
+
+    for (;;) {
+      const operations = [
+        ...(includeEmbeddings
+          ? [this.prisma.memoryEmbedding.deleteMany({
+              where: { memoryId: { in: memoryIds } },
+            })]
+          : []),
+        ...(includeUsage
+          ? [this.prisma.memoryUsage.deleteMany({
+              where: { memoryId: { in: memoryIds } },
+            })]
+          : []),
+        this.prisma.memoryLink.deleteMany({
+          where: { OR: [{ sourceId: { in: memoryIds } }, { targetId: { in: memoryIds } }] },
+        }),
+        this.prisma.tombstone.deleteMany({ where: { orgId, repoId } }),
+        this.prisma.memory.deleteMany({ where: { orgId, repoId } }),
+      ];
+
+      try {
+        const results = await this.prisma.$transaction(operations);
+        let resultIndex = 0;
+        const embeddingsDeleted = includeEmbeddings ? results[resultIndex++].count : 0;
+        if (includeUsage) {
+          resultIndex++;
+        }
+        const linksResult = results[resultIndex++];
+        resultIndex++; // Tombstones are deleted but not included in the public result.
+        const memoriesResult = results[resultIndex];
+
+        return {
+          memoriesDeleted: memoriesResult.count,
+          linksDeleted: linksResult.count,
+          embeddingsDeleted,
+        };
+      } catch (error) {
+        // Older remote schemas may not have these optional tables. A failed
+        // transaction is rolled back before retrying without the missing table.
+        if (includeEmbeddings && isMissingTableError(error, "public.memory_embeddings")) {
+          includeEmbeddings = false;
+          continue;
+        }
+        if (includeUsage && isMissingTableError(error, "public.memory_usage")) {
+          includeUsage = false;
+          continue;
+        }
         throw error;
       }
     }
-
-    try {
-      await this.prisma.memoryUsage.deleteMany({
-        where: { memoryId: { in: memoryIds } },
-      });
-    } catch (error) {
-      if (!isMissingTableError(error, "public.memory_usage")) {
-        throw error;
-      }
-    }
-
-    const [linksResult, , memoriesResult] = await this.prisma.$transaction([
-      this.prisma.memoryLink.deleteMany({
-        where: { OR: [{ sourceId: { in: memoryIds } }, { targetId: { in: memoryIds } }] },
-      }),
-      this.prisma.tombstone.deleteMany({ where: { orgId, repoId } }),
-      this.prisma.memory.deleteMany({ where: { orgId, repoId } }),
-    ]);
-
-    return {
-      memoriesDeleted: memoriesResult.count,
-      linksDeleted: linksResult.count,
-      embeddingsDeleted,
-    };
   }
 
   async upsertUser(input: {

--- a/packages/db/src/remote.ts
+++ b/packages/db/src/remote.ts
@@ -1597,6 +1597,7 @@ export class RemoteStore {
   ): Promise<{ memoriesDeleted: number; linksDeleted: number; embeddingsDeleted: number }> {
     let includeEmbeddings = true;
     let includeUsage = true;
+    let transactionConflictRetries = 0;
 
     for (;;) {
       const operations = [
@@ -1649,6 +1650,13 @@ export class RemoteStore {
         }
         if (includeUsage && isMissingTableError(error, "public.memory_usage")) {
           includeUsage = false;
+          continue;
+        }
+        const errorCode = error && typeof error === "object" && "code" in error
+          ? error.code
+          : undefined;
+        if (errorCode === "P2034" && transactionConflictRetries < 3) {
+          transactionConflictRetries++;
           continue;
         }
         throw error;


### PR DESCRIPTION
## Summary

- keep embedding, usage, link, tombstone, and memory deletion inside one database transaction
- scope child deletion through the current repository relation and use serializable isolation to prevent concurrent cross-repository moves from losing metadata
- retry bounded Prisma `P2034` serialization conflicts
- preserve compatibility with legacy schemas by retrying only after rollback, omitting optional missing embedding or usage tables
- add regression coverage for atomicity, scoping, isolation, conflicts, and legacy fallback

## Risk

Low and bounded to destructive remote reset. Successful reset counts and legacy-schema behavior are preserved.

## Verification

- TDD RED confirmed pre-transaction deletion, stale-ID scoping, and missing `P2034` retry
- Node 24.15.0 frozen install and Prisma generation
- ESLint
- 66 test files / 385 tests
- full monorepo build
- CLI and packed CLI smoke tests
- root pnpm audits: 0 vulnerabilities (all + production)
- isolated website npm audits: 0 vulnerabilities (all + production)
- Docker Compose rebuilt/recreated; API `/health`, admin, and website return 200; running image IDs match rebuilt images
- PR CI and CodeQL green