### PR TITLE
fix(api): close sync push scope race

### DIFF
--- a/apps/api/src/__tests__/sync.test.ts
+++ b/apps/api/src/__tests__/sync.test.ts
@@ -260,6 +260,53 @@ describe("sync routes", () => {
     await app.close();
   });
 
+  it("fails closed when a sync-push target moves outside the API key scope during the write", async () => {
+    const store = buildStore();
+    store.validateApiKey.mockResolvedValue({
+      id: "key-id",
+      orgId: "org-a",
+      repoId: "repo-a",
+      name: "test-key",
+    });
+    store.getById.mockResolvedValue(undefined);
+    store.upsertFromLocal.mockResolvedValue({
+      action: "skipped",
+      conflict: false,
+      forbidden: true,
+    });
+
+    const app = Fastify();
+    app.addHook("onRequest", createAuthMiddleware(store));
+    await app.register(syncRoutes, { store });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/sync/push",
+      headers: { authorization: "Bearer valid-token" },
+      payload: {
+        id: "memory-id",
+        orgId: "org-a",
+        repoId: "repo-a",
+        memoryType: "semantic",
+        visibility: "private",
+        status: "active",
+        text: "overwritten",
+        version: 100,
+        createdAt: "2026-09-11T09:00:00.000Z",
+        updatedAt: "2026-09-11T10:00:00.000Z",
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({ error: "Forbidden" });
+    expect(store.upsertFromLocal).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "memory-id" }),
+      { orgId: "org-a", repoId: "repo-a" },
+    );
+
+    await app.close();
+  });
+
   it("does not let a repository-scoped API key tombstone another repository's memory", async () => {
     const store = buildStore();
     store.validateApiKey.mockResolvedValue({

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -189,7 +189,14 @@ export const syncRoutes: FastifyPluginAsync<{ store: RemoteStore }> = async (
         updatedAt,
       };
 
-      const result = await store.upsertFromLocal(memory);
+      const result = await store.upsertFromLocal(memory, {
+        orgId: request.apiKey!.orgId,
+        repoId: request.apiKey!.repoId,
+      });
+
+      if (result.forbidden) {
+        return reply.status(403).send({ error: "Forbidden" });
+      }
 
       if (result.conflict) {
         const existing = await store.getById(body.id);

--- a/packages/db/src/__tests__/remote-sync.test.ts
+++ b/packages/db/src/__tests__/remote-sync.test.ts
@@ -40,4 +40,53 @@ describe("RemoteStore.upsertFromLocal", () => {
     });
     expect(prisma.memory.update).not.toHaveBeenCalled();
   });
+
+  it("fails closed when a memory moves outside the authorized scope before the final write", async () => {
+    const store = new RemoteStore("postgresql://user:***@localhost:5432/test");
+    const prisma = {
+      memory: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "memory-1",
+          orgId: "org-a",
+          repoId: "repo-a",
+          version: 1,
+          updatedAt: new Date("2026-09-11T10:00:00.000Z"),
+        }),
+        update: vi.fn(),
+        updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      $disconnect: vi.fn(),
+    };
+
+    (store as unknown as { prisma: typeof prisma }).prisma = prisma;
+
+    const memory: Memory = {
+      id: "memory-1",
+      orgId: "org-a",
+      repoId: "repo-a",
+      scopeType: "repo",
+      memoryType: "semantic",
+      visibility: "repo",
+      status: "active",
+      text: "authorized local content",
+      tags: [],
+      version: 2,
+      createdAt: new Date("2026-09-11T09:00:00.000Z"),
+      updatedAt: new Date("2026-09-11T11:00:00.000Z"),
+    };
+
+    await expect(
+      store.upsertFromLocal(memory, { orgId: "org-a", repoId: "repo-a" }),
+    ).resolves.toEqual({ action: "skipped", conflict: false, forbidden: true });
+    expect(prisma.memory.update).not.toHaveBeenCalled();
+    expect(prisma.memory.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: "memory-1",
+          orgId: "org-a",
+          repoId: "repo-a",
+        },
+      }),
+    );
+  });
 });

--- a/packages/db/src/remote.ts
+++ b/packages/db/src/remote.ts
@@ -952,11 +952,39 @@ export class RemoteStore {
     return rows.map((r) => prismaRowToMemory(r as unknown as Record<string, unknown>));
   }
 
-  async upsertFromLocal(memory: Memory): Promise<{ action: "created" | "updated" | "skipped"; conflict: boolean }> {
+  async upsertFromLocal(
+    memory: Memory,
+    authorizedScope?: StoreAuthorizationScope,
+  ): Promise<{
+    action: "created" | "updated" | "skipped";
+    conflict: boolean;
+    forbidden?: boolean;
+  }> {
     const existing = await this.prisma.memory.findUnique({ where: { id: memory.id } });
 
     const normalizedOrgId = memory.orgId.toLowerCase();
     const normalizedRepoId = memory.repoId.toLowerCase();
+    const normalizedAuthorizedOrgId = authorizedScope?.orgId.toLowerCase();
+    const normalizedAuthorizedRepoId = authorizedScope?.repoId?.toLowerCase() ?? null;
+
+    if (
+      authorizedScope &&
+      (normalizedAuthorizedOrgId !== normalizedOrgId ||
+        (normalizedAuthorizedRepoId !== null &&
+          normalizedAuthorizedRepoId !== normalizedRepoId))
+    ) {
+      return { action: "skipped", conflict: false, forbidden: true };
+    }
+
+    if (
+      existing &&
+      authorizedScope &&
+      (existing.orgId.toLowerCase() !== normalizedAuthorizedOrgId ||
+        (normalizedAuthorizedRepoId !== null &&
+          existing.repoId.toLowerCase() !== normalizedAuthorizedRepoId))
+    ) {
+      return { action: "skipped", conflict: false, forbidden: true };
+    }
 
     if (!existing) {
       await this.prisma.memory.create({
@@ -999,24 +1027,42 @@ export class RemoteStore {
       return { action: "skipped", conflict: true };
     }
 
-    await this.prisma.memory.update({
-      where: { id: memory.id },
-      data: {
-        memoryType: memory.memoryType,
-        visibility: memory.visibility,
-        status: memory.status,
-        text: memory.text,
-        summary: memory.summary,
-        tags: memory.tags ?? [],
-        sourceRefs: memory.sourceRefs as Record<string, string> | undefined,
-        confidence: memory.confidence,
-        ttlSeconds: memory.ttlSeconds,
-        supersedesId: memory.supersedesId,
-        version: Math.max(remoteVersion, localVersion) + 1,
-        deletedAt: memory.deletedAt,
-        deletedBy: memory.deletedBy,
-      },
-    });
+    const data = {
+      memoryType: memory.memoryType,
+      visibility: memory.visibility,
+      status: memory.status,
+      text: memory.text,
+      summary: memory.summary,
+      tags: memory.tags ?? [],
+      sourceRefs: memory.sourceRefs as Record<string, string> | undefined,
+      confidence: memory.confidence,
+      ttlSeconds: memory.ttlSeconds,
+      supersedesId: memory.supersedesId,
+      version: Math.max(remoteVersion, localVersion) + 1,
+      deletedAt: memory.deletedAt,
+      deletedBy: memory.deletedBy,
+    };
+
+    if (authorizedScope) {
+      const updated = await this.prisma.memory.updateMany({
+        where: {
+          id: memory.id,
+          orgId: normalizedAuthorizedOrgId,
+          ...(normalizedAuthorizedRepoId === null
+            ? {}
+            : { repoId: normalizedAuthorizedRepoId }),
+        },
+        data,
+      });
+      if (updated.count === 0) {
+        return { action: "skipped", conflict: false, forbidden: true };
+      }
+    } else {
+      await this.prisma.memory.update({
+        where: { id: memory.id },
+        data,
+      });
+    }
 
     return { action: "updated", conflict: false };
   }


### PR DESCRIPTION
## Summary
- enforce API-key scope again inside the remote sync upsert boundary
- condition the final update on the authorized organization/repository
- fail closed with HTTP 403 if scope changes during the write

## Security impact
Prevents a repository-scoped API key from overwriting a same-ID memory that appears or moves outside its scope between route authorization and the database write.

## TDD
- RED: focused API and database regressions both failed on the previous behavior
- GREEN: 21 focused tests pass
- changed-file ESLint passes
- database and API builds pass
- pnpm audit and production audit report no known vulnerabilities

Full repository gates are in progress.